### PR TITLE
Joythish's Sprint 1 improvements, covers issues #5, #6, #7, #8, #9 plus two bug fixes.

### DIFF
--- a/app/api/v1/events/[eventId]/route.ts
+++ b/app/api/v1/events/[eventId]/route.ts
@@ -1,10 +1,26 @@
 import { NextResponse } from 'next/server';
 import { adminDb } from '@/lib/firebase-admin';
 import { verifyAuth, successResponse, errorResponse } from '@/lib/api-helpers';
+import { FieldValue } from 'firebase-admin/firestore';
 
 /**
- * DELETE /api/v1/events/[eventId]
- * Delete a specific event
+ * @swagger
+ * /api/v1/events/{eventId}:
+ *   delete:
+ *     summary: Delete a specific event
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Event deleted successfully
+ *       404:
+ *         description: Event not found
  */
 export async function DELETE(
     request: Request,
@@ -13,7 +29,7 @@ export async function DELETE(
     try {
         const authResult = await verifyAuth(request);
         if (authResult.error || !authResult.user) {
-            return NextResponse.json(errorResponse('UNAUTHORIZED', 'Missing or invalid authorization token'), { status: 401 });
+            return errorResponse('Missing or invalid authorization token', 'UNAUTHORIZED', 401);
         }
 
         const { eventId } = await params;
@@ -26,14 +42,81 @@ export async function DELETE(
 
         const eventDoc = await eventRef.get();
         if (!eventDoc.exists) {
-            return NextResponse.json(errorResponse('NOT_FOUND', 'Event not found'), { status: 404 });
+            return errorResponse('Event not found', 'NOT_FOUND', 404);
         }
 
         await eventRef.delete();
 
-        return NextResponse.json(successResponse({ success: true }));
-    } catch (error) {
+        return successResponse({ success: true });
+    } catch (error: unknown) {
         console.error('Error deleting event:', error);
-        return NextResponse.json(errorResponse('INTERNAL_SERVER_ERROR', 'Failed to delete event'), { status: 500 });
+        return errorResponse('Failed to delete event', 'INTERNAL_SERVER_ERROR', 500);
+    }
+}
+
+/**
+ * @swagger
+ * /api/v1/events/{eventId}:
+ *   put:
+ *     summary: Update a specific event
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Event updated successfully
+ *       400:
+ *         description: Missing required fields
+ *       404:
+ *         description: Event not found
+ */
+export async function PUT(
+    request: Request,
+    { params }: { params: Promise<{ eventId: string }> }
+) {
+    try {
+        const authResult = await verifyAuth(request);
+        if (authResult.error || !authResult.user) {
+            return errorResponse('Missing or invalid authorization token', 'UNAUTHORIZED', 401);
+        }
+
+        const { eventId } = await params;
+        const body = await request.json();
+
+        if (!body.title || !body.startTime || !body.endTime) {
+            return errorResponse('Missing required fields: title, startTime, endTime', 'BAD_REQUEST', 400);
+        }
+
+        const eventRef = adminDb
+            .collection('users')
+            .doc(authResult.user.uid)
+            .collection('events')
+            .doc(eventId);
+
+        const eventDoc = await eventRef.get();
+        if (!eventDoc.exists) {
+            return errorResponse('Event not found', 'NOT_FOUND', 404);
+        }
+
+        const updateData = {
+            title: body.title,
+            startTime: body.startTime,
+            endTime: body.endTime,
+            location: body.location || '',
+            color: body.color || 'blue',
+            updatedAt: FieldValue.serverTimestamp(),
+        };
+
+        await eventRef.update(updateData);
+
+        return successResponse({ id: eventId, ...updateData });
+    } catch (error: unknown) {
+        console.error('Error updating event:', error);
+        return errorResponse('Failed to update event', 'INTERNAL_SERVER_ERROR', 500);
     }
 }

--- a/app/api/v1/events/route.ts
+++ b/app/api/v1/events/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: Request) {
     try {
         const authResult = await verifyAuth(request);
         if (authResult.error || !authResult.user) {
-            return NextResponse.json(errorResponse('UNAUTHORIZED', 'Missing or invalid authorization token'), { status: 401 });
+            return errorResponse('Missing or invalid authorization token', 'UNAUTHORIZED', 401);
         }
 
         const eventsSnapshot = await adminDb
@@ -27,10 +27,10 @@ export async function GET(request: Request) {
             // Ensure any Firestore Timestamps are strictly stripped if not safely returned
         }));
 
-        return NextResponse.json(successResponse(events));
-    } catch (error) {
+        return successResponse(events);
+    } catch (error: unknown) {
         console.error('Error fetching events:', error);
-        return NextResponse.json(errorResponse('INTERNAL_SERVER_ERROR', 'Failed to fetch events'), { status: 500 });
+        return errorResponse('Failed to fetch events', 'INTERNAL_SERVER_ERROR', 500);
     }
 }
 
@@ -42,14 +42,14 @@ export async function POST(request: Request) {
     try {
         const authResult = await verifyAuth(request);
         if (authResult.error || !authResult.user) {
-            return NextResponse.json(errorResponse('UNAUTHORIZED', 'Missing or invalid authorization token'), { status: 401 });
+            return errorResponse('Missing or invalid authorization token', 'UNAUTHORIZED', 401);
         }
 
         const body = await request.json();
         const { title, startTime, endTime, location, color } = body;
 
         if (!title || !startTime || !endTime) {
-            return NextResponse.json(errorResponse('BAD_REQUEST', 'Missing required fields'), { status: 400 });
+            return errorResponse('Missing required fields', 'BAD_REQUEST', 400);
         }
 
         const newEvent = {
@@ -68,9 +68,11 @@ export async function POST(request: Request) {
             .collection('events')
             .add(newEvent);
 
-        return NextResponse.json(successResponse({ id: docRef.id, ...newEvent }), { status: 201 });
-    } catch (error) {
+        const savedDoc = await docRef.get();
+
+        return successResponse({ id: docRef.id, ...savedDoc.data() }, 201);
+    } catch (error: unknown) {
         console.error('Error creating event:', error);
-        return NextResponse.json(errorResponse('INTERNAL_SERVER_ERROR', 'Failed to create event'), { status: 500 });
+        return errorResponse('Failed to create event', 'INTERNAL_SERVER_ERROR', 500);
     }
 }

--- a/app/api/v1/plans/[planId]/route.ts
+++ b/app/api/v1/plans/[planId]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest } from 'next/server';
 import { adminDb } from '@/lib/firebase-admin';
 import { verifyAuth, errorResponse, successResponse } from '@/lib/api-helpers';
 
+export const dynamic = 'force-dynamic';
+
 /**
  * @swagger
  * /api/v1/plans/{planId}:

--- a/app/api/v1/plans/[planId]/route.ts
+++ b/app/api/v1/plans/[planId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { adminDb } from '@/lib/firebase-admin';
 import { verifyAuth, errorResponse, successResponse } from '@/lib/api-helpers';
+import { FieldValue } from 'firebase-admin/firestore';
 
 export const dynamic = 'force-dynamic';
 
@@ -114,5 +115,81 @@ export async function DELETE(
     } catch (err) {
         console.error('Error deleting plan:', err);
         return errorResponse('Failed to delete degree plan', 'INTERNAL_SERVER_ERROR', 500);
+    }
+}
+
+/**
+ * @swagger
+ * /api/v1/plans/{planId}:
+ *   put:
+ *     summary: Rename a specific degree plan
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: planId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *             properties:
+ *               name:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Plan renamed successfully
+ *       400:
+ *         description: Missing or invalid name
+ *       404:
+ *         description: Plan not found
+ */
+export async function PUT(
+    request: NextRequest,
+    context: { params: Promise<{ planId: string }> }
+) {
+    const { user, error } = await verifyAuth(request);
+
+    if (error || !user) {
+        return errorResponse(error || 'Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    try {
+        const { planId } = await context.params;
+        const body = await request.json().catch(() => ({}));
+
+        if (!body.name || typeof body.name !== 'string' || body.name.trim() === '') {
+            return errorResponse('Valid plan name is required', 'BAD_REQUEST', 400);
+        }
+
+        const newName = body.name.trim();
+
+        const planRef = adminDb
+            .collection('users')
+            .doc(user.uid)
+            .collection('plans')
+            .doc(planId);
+
+        const planDoc = await planRef.get();
+
+        if (!planDoc.exists) {
+            return errorResponse(`Plan ${planId} not found.`, 'NOT_FOUND', 404);
+        }
+
+        await planRef.update({
+            name: newName,
+            updatedAt: FieldValue.serverTimestamp()
+        });
+
+        return successResponse({ id: planId, name: newName });
+    } catch (err) {
+        console.error('Error renaming plan:', err);
+        return errorResponse('Failed to rename degree plan', 'INTERNAL_SERVER_ERROR', 500);
     }
 }

--- a/app/api/v1/plans/route.ts
+++ b/app/api/v1/plans/route.ts
@@ -3,6 +3,8 @@ import { adminDb } from '@/lib/firebase-admin';
 import { verifyAuth, errorResponse, successResponse } from '@/lib/api-helpers';
 import { FieldValue } from 'firebase-admin/firestore';
 
+export const dynamic = 'force-dynamic';
+
 /**
  * @swagger
  * /api/v1/plans:
@@ -31,9 +33,19 @@ export async function GET(request: Request) {
             .orderBy('createdAt', 'desc')
             .get();
 
-        const plans = plansSnapshot.docs.map(doc => ({
-            id: doc.id,
-            ...doc.data()
+        const plans = await Promise.all(plansSnapshot.docs.map(async (doc) => {
+            const semestersSnapshot = await adminDb
+                .collection('users')
+                .doc(user.uid)
+                .collection('plans')
+                .doc(doc.id)
+                .collection('semesters')
+                .get();
+            return {
+                id: doc.id,
+                ...doc.data(),
+                semesterCount: semestersSnapshot.size
+            };
         }));
 
         return successResponse(plans);

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,21 +1,115 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useEvents, EventItem } from '@/hooks/useEvents';
 import { useAuth } from '@/hooks/useAuth';
 import * as ics from 'ics';
 import { useRouter } from 'next/navigation';
 
 const DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
-const HOURS = Array.from({ length: 13 }, (_, i) => i + 8); // 8 AM to 8 PM
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
 
 export default function CalendarPage() {
     const { user, loading: authLoading } = useAuth();
-    const { events, loading: eventsLoading, addEvent, deleteEvent } = useEvents();
+    const { events, loading: eventsLoading, addEvent, updateEvent, deleteEvent } = useEvents();
     const router = useRouter();
 
     const [isAdding, setIsAdding] = useState(false);
-    const [newEvent, setNewEvent] = useState({ title: '', day: 'Monday', startTime: '10:00', endTime: '11:00', location: '', color: 'blue' });
+    const [editingEventId, setEditingEventId] = useState<string | null>(null);
+
+    // Default to today's date in local time
+    const todayStr = new Date().toLocaleDateString('en-CA'); // Gets YYYY-MM-DD correctly in local timezone
+
+    const [newEvent, setNewEvent] = useState({
+        title: '',
+        date: todayStr,
+        startTime: '10:00',
+        endTime: '11:00',
+        location: '',
+        color: 'blue'
+    });
+
+    const handleEditEvent = (event: EventItem) => {
+        const start = new Date(event.startTime);
+        const end = new Date(event.endTime);
+        const dateStr = start.toLocaleDateString('en-CA');
+        const startTimeStr = `${start.getHours().toString().padStart(2, '0')}:${start.getMinutes().toString().padStart(2, '0')}`;
+        const endTimeStr = `${end.getHours().toString().padStart(2, '0')}:${end.getMinutes().toString().padStart(2, '0')}`;
+
+        setNewEvent({
+            title: event.title,
+            date: dateStr,
+            startTime: startTimeStr,
+            endTime: endTimeStr,
+            location: event.location || '',
+            color: event.color || 'blue'
+        });
+        setEditingEventId(event.id);
+        setIsAdding(true);
+    };
+
+    const handleCancelForm = () => {
+        setIsAdding(false);
+        setEditingEventId(null);
+        setNewEvent({ title: '', date: todayStr, startTime: '10:00', endTime: '11:00', location: '', color: 'blue' });
+    };
+
+    const processedEvents = useMemo(() => {
+        if (!events || !Array.isArray(events)) return [];
+
+        // Guard against corrupted database entries missing required fields
+        const validEvents = events.filter(e => e && e.startTime && e.endTime);
+
+        const enriched = validEvents.map(e => ({ ...e, startObj: new Date(e.startTime), endObj: new Date(e.endTime) }));
+        enriched.sort((a, b) => a.startObj.getTime() - b.startObj.getTime());
+
+        const finalEvents: (typeof enriched[0] & { overlapIndex: number; overlapTotal: number })[] = [];
+
+        // Group events by day
+        const eventsByDay: Record<string, typeof enriched> = {};
+        for (const e of enriched) {
+            const dayKey = e.startObj.toDateString(); // Use toDateString for local date comparison
+            if (!eventsByDay[dayKey]) eventsByDay[dayKey] = [];
+            eventsByDay[dayKey].push(e);
+        }
+
+        // Process each day for overlaps
+        for (const dayKey in eventsByDay) {
+            const dayEvents = eventsByDay[dayKey];
+            const columns: typeof dayEvents[] = []; // Each column holds non-overlapping events
+
+            for (const e of dayEvents) {
+                let placed = false;
+                // Try to place event in an existing column
+                for (let i = 0; i < columns.length; i++) {
+                    const col = columns[i];
+                    // Check if event 'e' overlaps with any event in 'col'
+                    const overlapsWithColumn = col.some(existingEvent =>
+                        (e.startObj < existingEvent.endObj && e.endObj > existingEvent.startObj)
+                    );
+
+                    if (!overlapsWithColumn) {
+                        col.push(e);
+                        placed = true;
+                        break;
+                    }
+                }
+                // If it couldn't be placed, create a new column
+                if (!placed) {
+                    columns.push([e]);
+                }
+            }
+
+            // Assign overlap properties to events
+            for (let i = 0; i < columns.length; i++) {
+                for (const e of columns[i]) {
+                    finalEvents.push({ ...e, overlapIndex: i, overlapTotal: columns.length });
+                }
+            }
+        }
+
+        return finalEvents;
+    }, [events]);
 
     if (authLoading || (!user && !authLoading)) {
         if (!authLoading && !user) router.push('/login');
@@ -54,177 +148,231 @@ export default function CalendarPage() {
 
     const handleAddSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        const dayMap: Record<string, number> = { 'Sunday': 0, 'Monday': 1, 'Tuesday': 2, 'Wednesday': 3, 'Thursday': 4, 'Friday': 5, 'Saturday': 6 };
-        const now = new Date();
-        const nextDay = new Date(now);
-        nextDay.setDate(now.getDate() + (dayMap[newEvent.day] + 7 - now.getDay()) % 7);
 
+        const [year, month, day] = newEvent.date.split('-').map(Number);
         const [startH, startM] = newEvent.startTime.split(':').map(Number);
         const [endH, endM] = newEvent.endTime.split(':').map(Number);
 
-        const startTime = new Date(nextDay);
-        startTime.setHours(startH, startM, 0, 0);
-
-        const endTime = new Date(nextDay);
-        endTime.setHours(endH, endM, 0, 0);
+        // Store dates in absolute local time using standard constructor
+        const startTime = new Date(year, month - 1, day, startH, startM);
+        const endTime = new Date(year, month - 1, day, endH, endM);
 
         try {
-            await addEvent({
-                title: newEvent.title,
-                startTime: startTime.toISOString(),
-                endTime: endTime.toISOString(),
-                location: newEvent.location,
-                color: newEvent.color
-            });
-            setIsAdding(false);
-        } catch (err: any) {
-            alert(err.message);
+            if (editingEventId) {
+                await updateEvent(editingEventId, {
+                    title: newEvent.title,
+                    startTime: startTime.toISOString(),
+                    endTime: endTime.toISOString(),
+                    location: newEvent.location,
+                    color: newEvent.color
+                });
+            } else {
+                await addEvent({
+                    title: newEvent.title,
+                    startTime: startTime.toISOString(),
+                    endTime: endTime.toISOString(),
+                    location: newEvent.location,
+                    color: newEvent.color
+                });
+            }
+            handleCancelForm();
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : 'Unknown error';
+            alert(message);
         }
     };
 
-    const getEventStyle = (event: EventItem) => {
-        const start = new Date(event.startTime);
-        const end = new Date(event.endTime);
-        const dayIdx = start.getDay() === 0 ? 6 : start.getDay() - 1; // Mon = 0
+    const getEventStyle = (event: typeof processedEvents[0]) => {
+        const start = event.startObj;
+        const end = event.endObj;
+        const dayIdx = start.getDay() === 0 ? 6 : start.getDay() - 1; // Mon = 0, Sun = 6
         const startHour = start.getHours() + (start.getMinutes() / 60);
         const endHour = end.getHours() + (end.getMinutes() / 60);
 
-        const top = (startHour - 8) * 60; // 60px per hour
+        const top = startHour * 60; // 60px per hour
         const height = (endHour - startHour) * 60;
+
+        let bg = '#eff6ff', border = '#3b82f6', text = '#1e3a8a';
+        if (event.color === 'red') { bg = '#fef2f2'; border = '#ef4444'; text = '#991b1b'; }
+        else if (event.color === 'green') { bg = '#f0fdf4'; border = '#22c55e'; text = '#166534'; }
+        else if (event.color === 'purple') { bg = '#faf5ff'; border = '#a855f7'; text = '#6b21a8'; }
+        else if (event.color === 'pink') { bg = '#fdf2f8'; border = '#ec4899'; text = '#9d174d'; }
+        else if (event.color === 'orange') { bg = '#fff7ed'; border = '#f97316'; text = '#c2410c'; }
 
         return {
             gridColumn: dayIdx + 2,
             top: `${top}px`,
             height: `${height}px`,
-            backgroundColor: event.color === 'blue' ? '#eff6ff' : event.color === 'red' ? '#fef2f2' : '#f0fdf4',
-            borderLeft: `4px solid ${event.color === 'blue' ? '#3b82f6' : event.color === 'red' ? '#ef4444' : '#22c55e'}`,
-            color: event.color === 'blue' ? '#1e3a8a' : event.color === 'red' ? '#991b1b' : '#166534',
+            backgroundColor: bg,
+            borderLeft: `4px solid ${event.overlapTotal > 1 ? '#f97316' : border}`, // subtle orange left border if overlapping
+            color: text,
         };
     };
 
     return (
-        <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
-            <div className="md:flex md:items-center md:justify-between mb-6">
-                <div className="flex-1 min-w-0">
-                    <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">
-                        My Weekly Schedule
-                    </h2>
-                </div>
-                <div className="mt-4 flex md:mt-0 md:ml-4 gap-3">
-                    <button
-                        onClick={() => setIsAdding(!isAdding)}
-                        className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                    >
-                        {isAdding ? 'Cancel Event' : 'Add Event'}
-                    </button>
-                    <button
-                        onClick={handleExport}
-                        className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                    >
-                        Export .ics
-                    </button>
-                </div>
-            </div>
-
-            {isAdding && (
-                <div className="bg-white p-4 shadow rounded-lg mb-6 border border-gray-200">
-                    <h3 className="text-lg font-bold mb-4">New Course Schedule Block</h3>
-                    <form onSubmit={handleAddSubmit} className="flex flex-wrap gap-4 items-end">
-                        <div className="w-48">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
-                            <input required type="text" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" placeholder="e.g. CS 3500" value={newEvent.title} onChange={e => setNewEvent({ ...newEvent, title: e.target.value })} />
-                        </div>
-                        <div className="w-32">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">Day</label>
-                            <select className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.day} onChange={e => setNewEvent({ ...newEvent, day: e.target.value })}>
-                                {DAYS.map(d => <option key={d}>{d}</option>)}
-                            </select>
-                        </div>
-                        <div className="w-24">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">Start</label>
-                            <input required type="time" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.startTime} onChange={e => setNewEvent({ ...newEvent, startTime: e.target.value })} />
-                        </div>
-                        <div className="w-24">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">End</label>
-                            <input required type="time" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.endTime} onChange={e => setNewEvent({ ...newEvent, endTime: e.target.value })} />
-                        </div>
-                        <div className="w-32">
-                            <label className="block text-sm font-medium text-gray-700 mb-1">Color Theme</label>
-                            <select className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.color} onChange={e => setNewEvent({ ...newEvent, color: e.target.value })}>
-                                <option value="blue">Blue</option>
-                                <option value="red">Red</option>
-                                <option value="green">Green</option>
-                            </select>
-                        </div>
-                        <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 text-sm font-medium transition-colors">Save</button>
-                    </form>
-                </div>
-            )}
-
-            <div className="bg-white shadow rounded-lg overflow-hidden border border-gray-200 flex flex-col">
-                <div className="grid grid-cols-[80px_1fr_1fr_1fr_1fr_1fr_1fr_1fr] border-b border-gray-200 bg-gray-50">
-                    <div className="p-3"></div>
-                    {DAYS.map(day => (
-                        <div key={day} className="p-3 text-center text-sm font-semibold text-gray-900 border-l border-gray-200">
-                            {day.substring(0, 3)}
-                        </div>
-                    ))}
+        <div className="min-h-screen bg-gray-50 pb-12">
+            <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
+                <div className="md:flex md:items-center md:justify-between mb-6">
+                    <div className="flex-1 min-w-0">
+                        <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                            My Weekly Schedule
+                        </h2>
+                    </div>
+                    <div className="mt-4 flex md:mt-0 md:ml-4 gap-3">
+                        {isAdding ? (
+                            <button
+                                onClick={handleCancelForm}
+                                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            >
+                                Cancel
+                            </button>
+                        ) : (
+                            <button
+                                onClick={() => setIsAdding(true)}
+                                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            >
+                                Add Event
+                            </button>
+                        )}
+                        <button
+                            onClick={handleExport}
+                            className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        >
+                            Export .ics
+                        </button>
+                    </div>
                 </div>
 
-                <div className="relative overflow-y-auto" style={{ height: '600px' }}>
-                    <div className="grid grid-cols-[80px_1fr_1fr_1fr_1fr_1fr_1fr_1fr]">
-                        <div className="flex flex-col">
-                            {HOURS.map(hour => (
-                                <div key={hour} className="h-[60px] border-b border-gray-100 pr-2 pt-1 text-right text-xs font-medium text-gray-500">
-                                    {hour > 12 ? hour - 12 : hour} {hour >= 12 ? 'PM' : 'AM'}
-                                </div>
-                            ))}
-                        </div>
+                {isAdding && (
+                    <div className="bg-white p-4 shadow rounded-lg mb-6 border border-gray-200">
+                        <h3 className="text-lg font-bold mb-4">{editingEventId ? 'Edit Event' : 'Add Event'}</h3>
+                        <form onSubmit={handleAddSubmit} className="flex flex-wrap gap-4 items-end">
+                            <div className="w-48">
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+                                <input required type="text" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" placeholder="e.g. CS 3500" value={newEvent.title} onChange={e => setNewEvent({ ...newEvent, title: e.target.value })} />
+                            </div>
+                            <div className="w-40">
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Date</label>
+                                <input required type="date" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.date} onChange={e => setNewEvent({ ...newEvent, date: e.target.value })} />
+                            </div>
+                            <div className="w-24">
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Start</label>
+                                <input required type="time" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.startTime} onChange={e => setNewEvent({ ...newEvent, startTime: e.target.value })} />
+                            </div>
+                            <div className="w-24">
+                                <label className="block text-sm font-medium text-gray-700 mb-1">End</label>
+                                <input required type="time" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.endTime} onChange={e => setNewEvent({ ...newEvent, endTime: e.target.value })} />
+                            </div>
+                            <div className="w-40">
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Location</label>
+                                <input type="text" className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" placeholder="e.g. ISEC 102" value={newEvent.location} onChange={e => setNewEvent({ ...newEvent, location: e.target.value })} />
+                            </div>
+                            <div className="w-32">
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Color Theme</label>
+                                <select className="w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 rounded-md py-1.5 px-3 border border-gray-300" value={newEvent.color} onChange={e => setNewEvent({ ...newEvent, color: e.target.value })}>
+                                    <option value="blue">Blue</option>
+                                    <option value="red">Red</option>
+                                    <option value="green">Green</option>
+                                    <option value="purple">Purple</option>
+                                    <option value="pink">Pink</option>
+                                    <option value="orange">Orange</option>
+                                </select>
+                            </div>
+                            <div className="flex gap-2">
+                                <button type="submit" className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 text-sm font-medium transition-colors">
+                                    {editingEventId ? 'Update Event' : 'Save'}
+                                </button>
+                                <button type="button" onClick={handleCancelForm} className="bg-gray-200 text-gray-700 px-4 py-2 rounded-md hover:bg-gray-300 text-sm font-medium transition-colors">
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                )}
+
+                <div className="bg-white shadow rounded-lg overflow-hidden border border-gray-200 flex flex-col">
+                    <div className="grid grid-cols-[80px_1fr_1fr_1fr_1fr_1fr_1fr_1fr] border-b border-gray-200 bg-gray-50">
+                        <div className="p-3"></div>
                         {DAYS.map(day => (
-                            <div key={`col-${day}`} className="border-l border-gray-100 relative">
-                                {HOURS.map(hour => (
-                                    <div key={`cell-${day}-${hour}`} className="h-[60px] border-b border-gray-100"></div>
-                                ))}
+                            <div key={day} className="p-3 text-center text-sm font-semibold text-gray-900 border-l border-gray-200">
+                                {day.substring(0, 3)}
                             </div>
                         ))}
                     </div>
 
-                    <div className="absolute top-0 left-0 right-0 grid grid-cols-[80px_1fr_1fr_1fr_1fr_1fr_1fr_1fr] pointer-events-none">
-                        <div className="col-start-2 col-end-9 relative pl-0.5 pr-0.5">
-                            {!eventsLoading && events.map((event) => {
-                                if (!event || !event.startTime || !event.endTime) return null;
-
-                                const style = getEventStyle(event);
-                                const leftPercentage = ((style.gridColumn - 2) / 7) * 100;
-                                const widthPercentage = 100 / 7;
-
-                                return (
-                                    <div
-                                        key={event.id}
-                                        className="absolute rounded-md p-1.5 shadow-sm overflow-hidden text-xs pointer-events-auto group hover:z-10 transition-all opacity-95 hover:opacity-100"
-                                        style={{
-                                            ...style,
-                                            left: `${leftPercentage}%`,
-                                            width: `calc(${widthPercentage}% - 8px)`,
-                                            marginLeft: '4px'
-                                        }}
-                                        title={`${event.title}`}
-                                    >
-                                        <div className="flex justify-between items-start">
-                                            <span className="font-bold truncate" style={{ color: style.color }}>{event.title}</span>
-                                            <button
-                                                onClick={() => {
-                                                    if (window.confirm('Delete event?')) deleteEvent(event.id);
-                                                }}
-                                                className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-600 focus:opacity-100"
-                                            >
-                                                ×
-                                            </button>
+                    <div className="relative overflow-y-auto" style={{ height: '600px' }}>
+                        <div className="grid grid-cols-[80px_1fr_1fr_1fr_1fr_1fr_1fr_1fr]">
+                            <div className="flex flex-col">
+                                {HOURS.map(hour => {
+                                    const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+                                    const ampm = hour >= 12 ? 'PM' : 'AM';
+                                    return (
+                                        <div key={hour} className="h-[60px] border-b border-gray-100 pr-2 pt-1 text-right text-xs font-medium text-gray-500">
+                                            {displayHour} {ampm}
                                         </div>
-                                        {event.location && <div className="truncate mt-0.5 opacity-80" style={{ color: style.color }}>{event.location}</div>}
-                                    </div>
-                                );
-                            })}
+                                    );
+                                })}
+                            </div>
+                            {DAYS.map(day => (
+                                <div key={`col-${day}`} className="border-l border-gray-100 relative">
+                                    {HOURS.map(hour => (
+                                        <div key={`cell-${day}-${hour}`} className="h-[60px] border-b border-gray-100"></div>
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+
+                        <div className="absolute top-0 left-0 right-0 grid grid-cols-[80px_1fr_1fr_1fr_1fr_1fr_1fr_1fr] pointer-events-none">
+                            <div className="col-start-2 col-end-9 relative pl-0.5 pr-0.5">
+                                {!eventsLoading && processedEvents.map((event) => {
+                                    if (!event || !event.startTime || !event.endTime) return null;
+
+                                    const style = getEventStyle(event);
+
+                                    // Calculate precise horizontal layout based on overlap
+                                    const baseColWidth = 100 / 7;
+                                    const overlapWidth = baseColWidth / event.overlapTotal;
+                                    const leftPercentage = ((style.gridColumn - 2) * baseColWidth) + (overlapWidth * event.overlapIndex);
+
+                                    return (
+                                        <div
+                                            key={event.id}
+                                            role="button"
+                                            tabIndex={0}
+                                            onKeyDown={(e) => { if (e.key === 'Enter') handleEditEvent(event); }}
+                                            className={`absolute rounded-md p-1.5 shadow-sm overflow-hidden text-xs pointer-events-auto group hover:z-10 transition-all opacity-95 hover:opacity-100 cursor-pointer ${event.overlapTotal > 1 ? 'ring-1 ring-orange-500/20' : ''}`}
+                                            style={{
+                                                ...style,
+                                                left: `${leftPercentage}%`,
+                                                width: `calc(${overlapWidth}% - 8px)`,
+                                                marginLeft: '4px'
+                                            }}
+                                            title={event.title}
+                                            onClick={() => handleEditEvent(event)}
+                                        >
+                                            <div className="flex justify-between items-start">
+                                                <span className="font-bold truncate" style={{ color: style.color }}>{event.title}</span>
+                                                <button
+                                                    aria-label="Delete event"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        if (window.confirm('Delete event?')) deleteEvent(event.id).catch(err => {
+                                                            alert(err instanceof Error ? err.message : 'Unknown error');
+                                                        });
+                                                    }}
+                                                    className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-600 focus:opacity-100 bg-white/50 rounded-full w-5 h-5 flex items-center justify-center shrink-0"
+                                                >
+                                                    ×
+                                                </button>
+                                            </div>
+                                            {event.location && <div className="truncate mt-0.5 opacity-80" style={{ color: style.color }}>{event.location}</div>}
+                                            {event.overlapTotal > 1 && (
+                                                <div className="absolute bottom-1 right-1 w-2 h-2 rounded-full bg-orange-400 opacity-50" title="Overlapping event" />
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ export default function DashboardPage() {
                                                 <Link key={plan.id} href={`/plans/${plan.id}`} className="block border border-gray-200 rounded-lg p-4 hover:border-indigo-300 hover:bg-indigo-50 transition-colors">
                                                     <div className="flex justify-between items-center">
                                                         <h3 className="font-semibold text-gray-900">{plan.name}</h3>
-                                                        <span className="text-sm text-gray-500">{plan.semesters?.length || 0} Semesters</span>
+                                                        <span className="text-sm text-gray-500">{plan.semesterCount || 0} Semesters</span>
                                                     </div>
                                                 </Link>
                                             ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -12,12 +12,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+
 
 body {
   background: var(--background);

--- a/app/plans/[planId]/page.tsx
+++ b/app/plans/[planId]/page.tsx
@@ -78,7 +78,9 @@ export default function PlanDetailsPage() {
         deleteSemester,
         reorderSemesters,
         moveCourseBetweenSemesters,
-        removeCourseFromSemester
+        removeCourseFromSemester,
+        addSemester,
+        addCourseToSemester
     } = usePlanDetails(planId);
 
     const router = useRouter();
@@ -320,12 +322,16 @@ export default function PlanDetailsPage() {
                     planId={planId}
                     isOpen={isAddSemesterOpen}
                     onClose={() => setIsAddSemesterOpen(false)}
+                    addSemester={addSemester}
+                    currentSemesterCount={plan.semesters?.length || 0}
                 />
 
                 <QuickAddModal
                     planId={planId}
                     isOpen={isQuickAddOpen}
                     onClose={() => setIsQuickAddOpen(false)}
+                    addCourseToSemester={addCourseToSemester}
+                    semesters={plan.semesters || []}
                 />
             </div>
         </div>

--- a/app/plans/[planId]/page.tsx
+++ b/app/plans/[planId]/page.tsx
@@ -12,7 +12,8 @@ import QuickAddModal from '@/components/QuickAddModal';
 import { TrashIcon, PlusIcon, MagnifyingGlassPlusIcon } from '@heroicons/react/24/outline';
 import { fetchCourseCached } from '@/hooks/useSingleCourse';
 import { CourseAssignment } from '@/hooks/usePlanDetails';
-
+import { CalendarIcon } from '@heroicons/react/24/outline';
+import AddScheduleToCalendarModal from '@/components/AddScheduleToCalendarModal';
 function SemesterCreditPill({ courses }: { courses: (string | CourseAssignment)[] }) {
     const [credits, setCredits] = useState<number>(0);
     const [loading, setLoading] = useState(true);
@@ -87,6 +88,7 @@ export default function PlanDetailsPage() {
 
     const [isAddSemesterOpen, setIsAddSemesterOpen] = useState(false);
     const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
+    const [isCalendarModalOpen, setIsCalendarModalOpen] = useState(false);
     const [isBrowser, setIsBrowser] = useState(false);
 
     useEffect(() => {
@@ -186,6 +188,13 @@ export default function PlanDetailsPage() {
                         </h2>
                     </div>
                     <div className="mt-4 flex flex-wrap gap-3 md:mt-0 md:ml-4">
+                        <button
+                            onClick={() => setIsCalendarModalOpen(true)}
+                            className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+                        >
+                            <CalendarIcon className="-ml-1 mr-2 h-5 w-5 text-gray-400" />
+                            Add to Calendar
+                        </button>
                         <button
                             onClick={() => setIsQuickAddOpen(true)}
                             className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
@@ -318,6 +327,12 @@ export default function PlanDetailsPage() {
                 </DragDropContext>
 
                 {/* Modals */}
+                <AddScheduleToCalendarModal
+                    isOpen={isCalendarModalOpen}
+                    onClose={() => setIsCalendarModalOpen(false)}
+                    semesters={plan.semesters || []}
+                />
+
                 <AddSemesterModal
                     planId={planId}
                     isOpen={isAddSemesterOpen}

--- a/app/plans/[planId]/page.tsx
+++ b/app/plans/[planId]/page.tsx
@@ -156,176 +156,178 @@ export default function PlanDetailsPage() {
     }
 
     return (
-        <div className="max-w-full mx-auto p-4 sm:p-6 lg:p-8">
-            <div className="md:flex md:items-center md:justify-between mb-8 max-w-7xl mx-auto">
-                <div className="flex-1 min-w-0">
-                    <nav className="flex" aria-label="Breadcrumb">
-                        <ol role="list" className="flex items-center space-x-4 mb-2">
-                            <li>
-                                <div>
-                                    <Link href="/plans" className="text-sm font-medium text-gray-500 hover:text-gray-700">
-                                        Plans
-                                    </Link>
-                                </div>
-                            </li>
-                            <li>
-                                <div className="flex items-center">
-                                    <svg className="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                        <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
-                                    </svg>
-                                    <span className="ml-4 text-sm font-medium text-gray-900">{plan.name}</span>
-                                </div>
-                            </li>
-                        </ol>
-                    </nav>
-                    <h2 className="text-3xl font-bold text-gray-900 sm:text-4xl">
-                        {plan.name}
-                    </h2>
-                </div>
-                <div className="mt-4 flex flex-wrap gap-3 md:mt-0 md:ml-4">
-                    <button
-                        onClick={() => setIsQuickAddOpen(true)}
-                        className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
-                    >
-                        <MagnifyingGlassPlusIcon className="-ml-1 mr-2 h-5 w-5" />
-                        Quick Add
-                    </button>
-                    <button
-                        onClick={() => setIsAddSemesterOpen(true)}
-                        className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
-                    >
-                        <PlusIcon className="-ml-1 mr-2 h-5 w-5 text-gray-400" />
-                        Add Semester
-                    </button>
-                </div>
-            </div>
-
-            <DragDropContext onDragEnd={onDragEnd}>
-                <Droppable droppableId="board" type="semester" direction="horizontal">
-                    {(provided) => (
-                        <div
-                            className="flex overflow-x-auto items-start gap-6 pb-8 min-h-[60vh] scroll-container max-w-7xl mx-auto"
-                            ref={provided.innerRef}
-                            {...provided.droppableProps}
+        <div className="min-h-screen bg-gray-50 pb-12">
+            <div className="max-w-full mx-auto p-4 sm:p-6 lg:p-8">
+                <div className="md:flex md:items-center md:justify-between mb-8 max-w-7xl mx-auto">
+                    <div className="flex-1 min-w-0">
+                        <nav className="flex" aria-label="Breadcrumb">
+                            <ol role="list" className="flex items-center space-x-4 mb-2">
+                                <li>
+                                    <div>
+                                        <Link href="/plans" className="text-sm font-medium text-gray-500 hover:text-gray-700">
+                                            Plans
+                                        </Link>
+                                    </div>
+                                </li>
+                                <li>
+                                    <div className="flex items-center">
+                                        <svg className="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                            <path fillRule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clipRule="evenodd" />
+                                        </svg>
+                                        <span className="ml-4 text-sm font-medium text-gray-900">{plan.name}</span>
+                                    </div>
+                                </li>
+                            </ol>
+                        </nav>
+                        <h2 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+                            {plan.name}
+                        </h2>
+                    </div>
+                    <div className="mt-4 flex flex-wrap gap-3 md:mt-0 md:ml-4">
+                        <button
+                            onClick={() => setIsQuickAddOpen(true)}
+                            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
                         >
-                            {plan.semesters.length === 0 ? (
-                                <div className="text-center bg-white rounded-lg border-2 border-dashed border-gray-300 p-12 w-full max-w-2xl mx-auto">
-                                    <h3 className="mt-2 text-sm font-semibold text-gray-900">No semesters defined</h3>
-                                    <p className="mt-1 text-sm text-gray-500 mb-4">Get started by creating your first semester.</p>
-                                    <button
-                                        onClick={() => setIsAddSemesterOpen(true)}
-                                        className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                                    >
-                                        <PlusIcon className="-ml-1 mr-2 h-5 w-5" />
-                                        Create Semester
-                                    </button>
-                                </div>
-                            ) : (
-                                plan.semesters.map((semester, index) => (
-                                    <Draggable key={semester.id} draggableId={semester.id} index={index}>
-                                        {(provided, snapshot) => (
-                                            <div
-                                                ref={provided.innerRef}
-                                                {...provided.draggableProps}
-                                                className={`w-80 shrink-0 bg-gray-100 rounded-xl p-3 flex flex-col border shadow-sm transition-colors ${snapshot.isDragging ? 'border-indigo-400 bg-indigo-50/50 ring-2 ring-indigo-500/20' : 'border-gray-200'}`}
-                                            >
+                            <MagnifyingGlassPlusIcon className="-ml-1 mr-2 h-5 w-5" />
+                            Quick Add
+                        </button>
+                        <button
+                            onClick={() => setIsAddSemesterOpen(true)}
+                            className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+                        >
+                            <PlusIcon className="-ml-1 mr-2 h-5 w-5 text-gray-400" />
+                            Add Semester
+                        </button>
+                    </div>
+                </div>
+
+                <DragDropContext onDragEnd={onDragEnd}>
+                    <Droppable droppableId="board" type="semester" direction="horizontal">
+                        {(provided) => (
+                            <div
+                                className="flex overflow-x-auto items-start gap-6 pb-8 min-h-[60vh] scroll-container max-w-7xl mx-auto"
+                                ref={provided.innerRef}
+                                {...provided.droppableProps}
+                            >
+                                {plan.semesters.length === 0 ? (
+                                    <div className="text-center bg-white rounded-lg border-2 border-dashed border-gray-300 p-12 w-full max-w-2xl mx-auto">
+                                        <h3 className="mt-2 text-sm font-semibold text-gray-900">No semesters defined</h3>
+                                        <p className="mt-1 text-sm text-gray-500 mb-4">Get started by creating your first semester.</p>
+                                        <button
+                                            onClick={() => setIsAddSemesterOpen(true)}
+                                            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                                        >
+                                            <PlusIcon className="-ml-1 mr-2 h-5 w-5" />
+                                            Create Semester
+                                        </button>
+                                    </div>
+                                ) : (
+                                    plan.semesters.map((semester, index) => (
+                                        <Draggable key={semester.id} draggableId={semester.id} index={index}>
+                                            {(provided, snapshot) => (
                                                 <div
-                                                    {...provided.dragHandleProps}
-                                                    className="flex justify-between items-center mb-4 px-1 cursor-grab active:cursor-grabbing group pt-1"
+                                                    ref={provided.innerRef}
+                                                    {...provided.draggableProps}
+                                                    className={`w-80 shrink-0 bg-gray-100 rounded-xl p-3 flex flex-col border shadow-sm transition-colors ${snapshot.isDragging ? 'border-indigo-400 bg-indigo-50/50 ring-2 ring-indigo-500/20' : 'border-gray-200'}`}
                                                 >
-                                                    <h3 className="text-sm font-bold text-gray-900 uppercase tracking-wide truncate pr-2">
-                                                        {semester.name}
-                                                    </h3>
-                                                    <div className="flex items-center gap-2 shrink-0">
-                                                        <SemesterCreditPill courses={semester.courses} />
-                                                        <button
-                                                            onClick={(e) => {
-                                                                e.stopPropagation();
-                                                                if (confirm(`Are you sure you want to delete ${semester.name}? All contained courses will be removed from your plan.`)) {
-                                                                    deleteSemester(semester.id).catch(err => alert(err.message));
-                                                                }
-                                                            }}
-                                                            className="text-gray-400 hover:text-red-600 p-1 rounded hover:bg-red-50 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
-                                                            title="Delete Semester"
-                                                        >
-                                                            <TrashIcon className="w-4 h-4" />
-                                                        </button>
-                                                    </div>
-                                                </div>
-
-                                                <Droppable droppableId={semester.id} type="course">
-                                                    {(provided, snapshot) => (
-                                                        <div
-                                                            ref={provided.innerRef}
-                                                            {...provided.droppableProps}
-                                                            className={`flex flex-col gap-3 min-h-[150px] rounded-lg transition-colors duration-200 ${snapshot.isDraggingOver ? 'bg-indigo-50 outline-dashed outline-2 outline-indigo-300 outline-offset-[-2px] p-2 -m-2' : ''}`}
-                                                        >
-                                                            {semester.courses.length === 0 ? (
-                                                                <div className="h-full flex items-center justify-center py-6 border-2 border-dashed border-gray-200 rounded-lg bg-gray-50/50">
-                                                                    <p className="text-gray-400 text-sm italic">No courses added</p>
-                                                                </div>
-                                                            ) : (
-                                                                semester.courses.map((courseItem, idx) => {
-                                                                    const cid = typeof courseItem === 'string' ? courseItem : courseItem.courseId;
-                                                                    const crn = typeof courseItem === 'string' ? undefined : courseItem.crn;
-                                                                    const draggableCourseId = `${semester.id}-${cid}-${idx}`;
-
-                                                                    return (
-                                                                        <Draggable key={draggableCourseId} draggableId={draggableCourseId} index={idx}>
-                                                                            {(provided, snapshot) => (
-                                                                                <div
-                                                                                    ref={provided.innerRef}
-                                                                                    {...provided.draggableProps}
-                                                                                    {...provided.dragHandleProps}
-                                                                                    className={`rounded-lg transition-transform ${snapshot.isDragging ? 'ring-2 ring-indigo-500 shadow-xl opacity-90 rotate-2' : ''}`}
-                                                                                >
-                                                                                    <CourseMiniCard
-                                                                                        courseId={cid}
-                                                                                        crn={crn}
-                                                                                        allPlanCourses={allPlanCourses}
-                                                                                        currentSemesterOrder={semester.order}
-                                                                                        onRemove={() => {
-                                                                                            if (confirm(`Remove ${cid} from ${semester.name}?`)) {
-                                                                                                removeCourseFromSemester(semester.id, cid)
-                                                                                                    .catch(err => alert(err.message));
-                                                                                            }
-                                                                                        }}
-                                                                                    />
-                                                                                </div>
-                                                                            )}
-                                                                        </Draggable>
-                                                                    );
-                                                                })
-                                                            )}
-                                                            {provided.placeholder}
+                                                    <div
+                                                        {...provided.dragHandleProps}
+                                                        className="flex justify-between items-center mb-4 px-1 cursor-grab active:cursor-grabbing group pt-1"
+                                                    >
+                                                        <h3 className="text-sm font-bold text-gray-900 uppercase tracking-wide truncate pr-2">
+                                                            {semester.name}
+                                                        </h3>
+                                                        <div className="flex items-center gap-2 shrink-0">
+                                                            <SemesterCreditPill courses={semester.courses} />
+                                                            <button
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    if (confirm(`Are you sure you want to delete ${semester.name}? All contained courses will be removed from your plan.`)) {
+                                                                        deleteSemester(semester.id).catch(err => alert(err.message));
+                                                                    }
+                                                                }}
+                                                                className="text-gray-400 hover:text-red-600 p-1 rounded hover:bg-red-50 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+                                                                title="Delete Semester"
+                                                            >
+                                                                <TrashIcon className="w-4 h-4" />
+                                                            </button>
                                                         </div>
-                                                    )}
-                                                </Droppable>
-                                            </div>
-                                        )}
-                                    </Draggable>
-                                ))
-                            )}
-                            {provided.placeholder}
-                            {/* Right Edge Scroll Spacer */}
-                            {plan.semesters.length > 0 && <div className="w-2 sm:w-4 lg:w-6 shrink-0" aria-hidden="true" />}
-                        </div>
-                    )}
-                </Droppable>
-            </DragDropContext>
+                                                    </div>
 
-            {/* Modals */}
-            <AddSemesterModal
-                planId={planId}
-                isOpen={isAddSemesterOpen}
-                onClose={() => setIsAddSemesterOpen(false)}
-            />
+                                                    <Droppable droppableId={semester.id} type="course">
+                                                        {(provided, snapshot) => (
+                                                            <div
+                                                                ref={provided.innerRef}
+                                                                {...provided.droppableProps}
+                                                                className={`flex flex-col gap-3 min-h-[150px] rounded-lg transition-colors duration-200 ${snapshot.isDraggingOver ? 'bg-indigo-50 outline-dashed outline-2 outline-indigo-300 outline-offset-[-2px] p-2 -m-2' : ''}`}
+                                                            >
+                                                                {semester.courses.length === 0 ? (
+                                                                    <div className="h-full flex items-center justify-center py-6 border-2 border-dashed border-gray-200 rounded-lg bg-gray-50/50">
+                                                                        <p className="text-gray-400 text-sm italic">No courses added</p>
+                                                                    </div>
+                                                                ) : (
+                                                                    semester.courses.map((courseItem, idx) => {
+                                                                        const cid = typeof courseItem === 'string' ? courseItem : courseItem.courseId;
+                                                                        const crn = typeof courseItem === 'string' ? undefined : courseItem.crn;
+                                                                        const draggableCourseId = `${semester.id}-${cid}-${idx}`;
 
-            <QuickAddModal
-                planId={planId}
-                isOpen={isQuickAddOpen}
-                onClose={() => setIsQuickAddOpen(false)}
-            />
+                                                                        return (
+                                                                            <Draggable key={draggableCourseId} draggableId={draggableCourseId} index={idx}>
+                                                                                {(provided, snapshot) => (
+                                                                                    <div
+                                                                                        ref={provided.innerRef}
+                                                                                        {...provided.draggableProps}
+                                                                                        {...provided.dragHandleProps}
+                                                                                        className={`rounded-lg transition-transform ${snapshot.isDragging ? 'ring-2 ring-indigo-500 shadow-xl opacity-90 rotate-2' : ''}`}
+                                                                                    >
+                                                                                        <CourseMiniCard
+                                                                                            courseId={cid}
+                                                                                            crn={crn}
+                                                                                            allPlanCourses={allPlanCourses}
+                                                                                            currentSemesterOrder={semester.order}
+                                                                                            onRemove={() => {
+                                                                                                if (confirm(`Remove ${cid} from ${semester.name}?`)) {
+                                                                                                    removeCourseFromSemester(semester.id, cid)
+                                                                                                        .catch(err => alert(err.message));
+                                                                                                }
+                                                                                            }}
+                                                                                        />
+                                                                                    </div>
+                                                                                )}
+                                                                            </Draggable>
+                                                                        );
+                                                                    })
+                                                                )}
+                                                                {provided.placeholder}
+                                                            </div>
+                                                        )}
+                                                    </Droppable>
+                                                </div>
+                                            )}
+                                        </Draggable>
+                                    ))
+                                )}
+                                {provided.placeholder}
+                                {/* Right Edge Scroll Spacer */}
+                                {plan.semesters.length > 0 && <div className="w-2 sm:w-4 lg:w-6 shrink-0" aria-hidden="true" />}
+                            </div>
+                        )}
+                    </Droppable>
+                </DragDropContext>
+
+                {/* Modals */}
+                <AddSemesterModal
+                    planId={planId}
+                    isOpen={isAddSemesterOpen}
+                    onClose={() => setIsAddSemesterOpen(false)}
+                />
+
+                <QuickAddModal
+                    planId={planId}
+                    isOpen={isQuickAddOpen}
+                    onClose={() => setIsQuickAddOpen(false)}
+                />
+            </div>
         </div>
     );
 }

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -8,11 +8,15 @@ import Link from 'next/link';
 
 export default function PlansPage() {
     const { user, loading: authLoading } = useAuth();
-    const { plans, loading: plansLoading, error, createPlan, deletePlan } = usePlans();
+    const { plans, loading: plansLoading, error, createPlan, deletePlan, renamePlan } = usePlans();
     const router = useRouter();
 
     const [newPlanName, setNewPlanName] = useState('');
     const [isCreating, setIsCreating] = useState(false);
+
+    const [renamingId, setRenamingId] = useState<string | null>(null);
+    const [renameValue, setRenameValue] = useState('');
+    const [isRenaming, setIsRenaming] = useState(false);
 
     useEffect(() => {
         if (!authLoading && !user) {
@@ -33,6 +37,24 @@ export default function PlansPage() {
             alert('Failed to create plan.');
         } finally {
             setIsCreating(false);
+        }
+    };
+
+    const handleRename = async (planId: string) => {
+        if (!renameValue.trim()) return;
+        try {
+            setIsRenaming(true);
+            await renamePlan(planId, renameValue.trim());
+            setRenamingId(null);
+        } catch (err: unknown) {
+            console.error('Failed to rename plan:', err);
+            if (err instanceof Error) {
+                alert(err.message);
+            } else {
+                alert('Failed to rename plan.');
+            }
+        } finally {
+            setIsRenaming(false);
         }
     };
 
@@ -117,16 +139,59 @@ export default function PlansPage() {
                                     <div className="px-4 py-4 flex items-center sm:px-6 hover:bg-gray-50 transition-colors">
                                         <div className="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
                                             <div className="truncate">
-                                                <div className="flex text-sm">
-                                                    <p className="font-semibold text-indigo-600 hover:text-indigo-800 truncate">
-                                                        <Link href={`/plans/${plan.id}`}>
-                                                            {plan.name}
-                                                        </Link>
-                                                    </p>
+                                                <div className="flex text-sm w-full">
+                                                    {renamingId === plan.id ? (
+                                                        <div className="flex items-center space-x-2 w-full">
+                                                            <input
+                                                                type="text"
+                                                                autoFocus
+                                                                className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md py-1 px-2 border"
+                                                                value={renameValue}
+                                                                onChange={(e) => setRenameValue(e.target.value)}
+                                                                onKeyDown={(e) => {
+                                                                    if (e.key === 'Enter') handleRename(plan.id);
+                                                                    if (e.key === 'Escape') setRenamingId(null);
+                                                                }}
+                                                                disabled={isRenaming}
+                                                            />
+                                                            <button
+                                                                onClick={() => handleRename(plan.id)}
+                                                                disabled={isRenaming}
+                                                                className="inline-flex items-center px-2 py-1 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50"
+                                                            >
+                                                                Save
+                                                            </button>
+                                                            <button
+                                                                onClick={() => setRenamingId(null)}
+                                                                disabled={isRenaming}
+                                                                className="inline-flex items-center px-2 py-1 border border-gray-300 text-xs font-medium rounded shadow-sm text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+                                                            >
+                                                                Cancel
+                                                            </button>
+                                                        </div>
+                                                    ) : (
+                                                        <p className="font-semibold text-indigo-600 hover:text-indigo-800 truncate">
+                                                            <Link href={`/plans/${plan.id}`}>
+                                                                {plan.name}
+                                                            </Link>
+                                                        </p>
+                                                    )}
                                                 </div>
                                             </div>
                                         </div>
                                         <div className="ml-5 flex-shrink-0 flex items-center space-x-4">
+                                            {renamingId !== plan.id && (
+                                                <button
+                                                    onClick={() => {
+                                                        setRenamingId(plan.id);
+                                                        setRenameValue(plan.name);
+                                                    }}
+                                                    className="text-gray-500 hover:text-indigo-600 text-sm font-medium"
+                                                    aria-label={`Rename ${plan.name}`}
+                                                >
+                                                    Rename
+                                                </button>
+                                            )}
                                             <Link
                                                 href={`/plans/${plan.id}`}
                                                 className="px-3 py-1 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -48,109 +48,111 @@ export default function PlansPage() {
     }
 
     return (
-        <div className="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8">
-            <div className="md:flex md:items-center md:justify-between mb-8">
-                <div className="flex-1 min-w-0">
-                    <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">
-                        My Degree Plans
-                    </h2>
+        <div className="min-h-screen bg-gray-50 pb-12">
+            <div className="max-w-4xl mx-auto p-4 sm:p-6 lg:p-8">
+                <div className="md:flex md:items-center md:justify-between mb-8">
+                    <div className="flex-1 min-w-0">
+                        <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                            My Degree Plans
+                        </h2>
+                    </div>
                 </div>
-            </div>
 
-            {error && (
-                <div className="rounded-md bg-red-50 p-4 mb-6">
-                    <div className="flex">
-                        <div className="ml-3">
-                            <h3 className="text-sm font-medium text-red-800">Error loading plans</h3>
-                            <div className="mt-2 text-sm text-red-700">{error}</div>
+                {error && (
+                    <div className="rounded-md bg-red-50 p-4 mb-6">
+                        <div className="flex">
+                            <div className="ml-3">
+                                <h3 className="text-sm font-medium text-red-800">Error loading plans</h3>
+                                <div className="mt-2 text-sm text-red-700">{error}</div>
+                            </div>
                         </div>
                     </div>
-                </div>
-            )}
+                )}
 
-            <div className="bg-white shadow sm:rounded-lg overflow-hidden mb-8 border border-gray-200">
-                <div className="px-4 py-5 sm:p-6 border-b border-gray-200 bg-gray-50">
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">
-                        Create a new plan
-                    </h3>
-                    <div className="mt-2 max-w-xl text-sm text-gray-500">
-                        <p>Give your degree tracking plan a distinct name (e.g. Master CS Track).</p>
-                    </div>
-                    <form className="mt-5 sm:flex sm:items-center" onSubmit={handleCreatePlan}>
-                        <div className="w-full sm:max-w-xs">
-                            <label htmlFor="planName" className="sr-only">Plan name</label>
-                            <input
-                                type="text"
-                                name="planName"
-                                id="planName"
-                                className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md py-2 px-3 border"
-                                placeholder="E.g. Full Stack Engineering"
-                                value={newPlanName}
-                                onChange={(e) => setNewPlanName(e.target.value)}
+                <div className="bg-white shadow sm:rounded-lg overflow-hidden mb-8 border border-gray-200">
+                    <div className="px-4 py-5 sm:p-6 border-b border-gray-200 bg-gray-50">
+                        <h3 className="text-lg leading-6 font-medium text-gray-900">
+                            Create a new plan
+                        </h3>
+                        <div className="mt-2 max-w-xl text-sm text-gray-500">
+                            <p>Give your degree tracking plan a distinct name (e.g. Master CS Track).</p>
+                        </div>
+                        <form className="mt-5 sm:flex sm:items-center" onSubmit={handleCreatePlan}>
+                            <div className="w-full sm:max-w-xs">
+                                <label htmlFor="planName" className="sr-only">Plan name</label>
+                                <input
+                                    type="text"
+                                    name="planName"
+                                    id="planName"
+                                    className="shadow-sm focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-sm border-gray-300 rounded-md py-2 px-3 border"
+                                    placeholder="E.g. Full Stack Engineering"
+                                    value={newPlanName}
+                                    onChange={(e) => setNewPlanName(e.target.value)}
+                                    disabled={isCreating}
+                                    required
+                                />
+                            </div>
+                            <button
+                                type="submit"
                                 disabled={isCreating}
-                                required
-                            />
-                        </div>
-                        <button
-                            type="submit"
-                            disabled={isCreating}
-                            className="mt-3 w-full inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
-                        >
-                            {isCreating ? 'Creating...' : 'Create Plan'}
-                        </button>
-                    </form>
-                </div>
+                                className="mt-3 w-full inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm disabled:opacity-50"
+                            >
+                                {isCreating ? 'Creating...' : 'Create Plan'}
+                            </button>
+                        </form>
+                    </div>
 
-                {plansLoading ? (
-                    <div className="p-8 flex justify-center">
-                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
-                    </div>
-                ) : plans.length === 0 ? (
-                    <div className="p-8 text-center text-gray-500">
-                        You haven't created any degree plans yet.
-                    </div>
-                ) : (
-                    <ul role="list" className="divide-y divide-gray-200">
-                        {plans.map((plan) => (
-                            <li key={plan.id}>
-                                <div className="px-4 py-4 flex items-center sm:px-6 hover:bg-gray-50 transition-colors">
-                                    <div className="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
-                                        <div className="truncate">
-                                            <div className="flex text-sm">
-                                                <p className="font-semibold text-indigo-600 hover:text-indigo-800 truncate">
-                                                    <Link href={`/plans/${plan.id}`}>
-                                                        {plan.name}
-                                                    </Link>
-                                                </p>
+                    {plansLoading ? (
+                        <div className="p-8 flex justify-center">
+                            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+                        </div>
+                    ) : plans.length === 0 ? (
+                        <div className="p-8 text-center text-gray-500">
+                            You haven't created any degree plans yet.
+                        </div>
+                    ) : (
+                        <ul role="list" className="divide-y divide-gray-200">
+                            {plans.map((plan) => (
+                                <li key={plan.id}>
+                                    <div className="px-4 py-4 flex items-center sm:px-6 hover:bg-gray-50 transition-colors">
+                                        <div className="min-w-0 flex-1 sm:flex sm:items-center sm:justify-between">
+                                            <div className="truncate">
+                                                <div className="flex text-sm">
+                                                    <p className="font-semibold text-indigo-600 hover:text-indigo-800 truncate">
+                                                        <Link href={`/plans/${plan.id}`}>
+                                                            {plan.name}
+                                                        </Link>
+                                                    </p>
+                                                </div>
                                             </div>
                                         </div>
+                                        <div className="ml-5 flex-shrink-0 flex items-center space-x-4">
+                                            <Link
+                                                href={`/plans/${plan.id}`}
+                                                className="px-3 py-1 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
+                                            >
+                                                View
+                                            </Link>
+                                            <button
+                                                onClick={() => {
+                                                    if (window.confirm(`Are you sure you want to delete "${plan.name}"?`)) {
+                                                        deletePlan(plan.id).catch(err => alert(err.message));
+                                                    }
+                                                }}
+                                                className="text-red-500 hover:text-red-700"
+                                                aria-label={`Delete ${plan.name}`}
+                                            >
+                                                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                                    <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                                                </svg>
+                                            </button>
+                                        </div>
                                     </div>
-                                    <div className="ml-5 flex-shrink-0 flex items-center space-x-4">
-                                        <Link
-                                            href={`/plans/${plan.id}`}
-                                            className="px-3 py-1 bg-white border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
-                                        >
-                                            View
-                                        </Link>
-                                        <button
-                                            onClick={() => {
-                                                if (window.confirm(`Are you sure you want to delete "${plan.name}"?`)) {
-                                                    deletePlan(plan.id).catch(err => alert(err.message));
-                                                }
-                                            }}
-                                            className="text-red-500 hover:text-red-700"
-                                            aria-label={`Delete ${plan.name}`}
-                                        >
-                                            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                                                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-                                            </svg>
-                                        </button>
-                                    </div>
-                                </div>
-                            </li>
-                        ))}
-                    </ul>
-                )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/components/AddScheduleToCalendarModal.test.tsx
+++ b/components/AddScheduleToCalendarModal.test.tsx
@@ -71,7 +71,23 @@ describe('AddScheduleToCalendarModal', () => {
         expect(container.firstChild).toBeNull();
     });
 
-    test('shows all courses for selected semester with or without CRNs', async () => {
+    test('shows "No courses in this semester have a specific section selected" when no CRNs are selected', async () => {
+        const semesterNoCrns = [{
+            id: 'sem2',
+            name: 'Spring 2027',
+            order: 1,
+            courses: ['CS2500', 'NOSECTIONS']
+        }];
+        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={semesterNoCrns} />);
+
+        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem2' } });
+
+        await waitFor(() => {
+            expect(screen.getByText(/No courses in this semester have a specific section selected/)).toBeDefined();
+        });
+    });
+
+    test('shows ONLY courses with pre-selected sections', async () => {
         render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
 
         // Select the semester
@@ -79,40 +95,15 @@ describe('AddScheduleToCalendarModal', () => {
 
         // Wait for courses to load and render
         await waitFor(() => {
-            expect(screen.getByText('CS2500')).toBeDefined();
+            // CS2510 has a CRN, should be displayed
             expect(screen.getByText('CS2510')).toBeDefined();
-            expect(screen.getByText('NOSECTIONS')).toBeDefined();
+            // CS2500 and NOSECTIONS do not have a CRN, should NOT be displayed
+            expect(screen.queryByText('CS2500')).toBeNull();
+            expect(screen.queryByText('NOSECTIONS')).toBeNull();
         });
     });
 
-    test('shows section dropdown when course has sections', async () => {
-        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
-
-        // Select the semester
-        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
-
-        await waitFor(() => {
-            // Check if dropdown exists with the correct options
-            const cs2500Select = screen.getByRole('combobox', { name: 'Select section for CS2500' });
-            expect(cs2500Select).toBeDefined();
-
-            // Should contain the default option plus the 2 sections
-            expect(cs2500Select.children.length).toBe(3);
-            expect(screen.getByText('CRN 10001 - MWF 10:00am - 11:00am')).toBeDefined();
-        });
-    });
-
-    test('shows "No sections available" message when course has no sections', async () => {
-        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
-
-        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
-
-        await waitFor(() => {
-            expect(screen.getByText('No sections available')).toBeDefined();
-        });
-    });
-
-    test('Add to Calendar button appears only when a section is selected', async () => {
+    test('Add to Calendar button appears for pre-selected sections', async () => {
         render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
 
         fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
@@ -120,18 +111,6 @@ describe('AddScheduleToCalendarModal', () => {
         await waitFor(() => {
             // CS2510 has a pre-selected CRN of 12345 so button should appear
             expect(screen.getByTestId('add-btn-CS2510-12345')).toBeDefined();
-
-            // CS2500 has NO pre-selected CRN, so button should NOT be there yet
-            expect(screen.queryByTestId(/add-btn-CS2500/)).toBeNull();
-        });
-
-        // Now select a section for CS2500
-        const cs2500Select = screen.getByRole('combobox', { name: 'Select section for CS2500' });
-        fireEvent.change(cs2500Select, { target: { value: '10002' } });
-
-        // Wait for rerender and verify button appeared
-        await waitFor(() => {
-            expect(screen.getByTestId('add-btn-CS2500-10002')).toBeDefined();
         });
     });
 });

--- a/components/AddScheduleToCalendarModal.test.tsx
+++ b/components/AddScheduleToCalendarModal.test.tsx
@@ -1,0 +1,137 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import AddScheduleToCalendarModal from './AddScheduleToCalendarModal';
+import { fetchCourseCached } from '@/hooks/useSingleCourse';
+
+// Mock dependencies
+vi.mock('@/hooks/useSingleCourse', () => ({
+    fetchCourseCached: vi.fn(),
+}));
+
+// Mock the AddToCalendarButton since we are only testing the modal
+vi.mock('./AddToCalendarButton', () => ({
+    AddToCalendarButton: vi.fn(({ courseId, crn }) => (
+        <button data-testid={`add-btn-${courseId}-${crn}`}>Add {courseId} CRN {crn}</button>
+    )),
+}));
+
+describe('AddScheduleToCalendarModal', () => {
+    const mockSemesters = [
+        {
+            id: 'sem1',
+            name: 'Fall 2026',
+            order: 0,
+            courses: [
+                'CS2500', // String course (no CRN)
+                { courseId: 'CS2510', crn: '12345' }, // Course with pre-selected CRN
+                'NOSECTIONS', // Course that will have no sections
+            ],
+        },
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // Setup default mock responses for fetchCourseCached
+        (fetchCourseCached as any).mockImplementation((courseId: string) => {
+            if (courseId === 'CS2500') {
+                return Promise.resolve({
+                    id: 'CS2500',
+                    name: 'Fundies 1',
+                    sections: [
+                        { crn: '10001', meetingTimes: 'MWF 10:00am - 11:00am' },
+                        { crn: '10002', meetingTimes: 'TR 1:00pm - 2:40pm' },
+                    ]
+                });
+            }
+            if (courseId === 'CS2510') {
+                return Promise.resolve({
+                    id: 'CS2510',
+                    name: 'Fundies 2',
+                    sections: [
+                        { crn: '12345', meetingTimes: 'MWF 2:00pm - 3:00pm' },
+                    ]
+                });
+            }
+            if (courseId === 'NOSECTIONS') {
+                return Promise.resolve({
+                    id: 'NOSECTIONS',
+                    name: 'Empty Course',
+                    sections: []
+                });
+            }
+            return Promise.resolve({ id: courseId, name: courseId, sections: [] });
+        });
+    });
+
+    test('renders nothing when not open', () => {
+        const { container } = render(
+            <AddScheduleToCalendarModal isOpen={false} onClose={vi.fn()} semesters={mockSemesters} />
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    test('shows all courses for selected semester with or without CRNs', async () => {
+        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
+
+        // Select the semester
+        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
+
+        // Wait for courses to load and render
+        await waitFor(() => {
+            expect(screen.getByText('CS2500')).toBeDefined();
+            expect(screen.getByText('CS2510')).toBeDefined();
+            expect(screen.getByText('NOSECTIONS')).toBeDefined();
+        });
+    });
+
+    test('shows section dropdown when course has sections', async () => {
+        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
+
+        // Select the semester
+        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
+
+        await waitFor(() => {
+            // Check if dropdown exists with the correct options
+            const cs2500Select = screen.getByRole('combobox', { name: 'Select section for CS2500' });
+            expect(cs2500Select).toBeDefined();
+
+            // Should contain the default option plus the 2 sections
+            expect(cs2500Select.children.length).toBe(3);
+            expect(screen.getByText('CRN 10001 - MWF 10:00am - 11:00am')).toBeDefined();
+        });
+    });
+
+    test('shows "No sections available" message when course has no sections', async () => {
+        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
+
+        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
+
+        await waitFor(() => {
+            expect(screen.getByText('No sections available')).toBeDefined();
+        });
+    });
+
+    test('Add to Calendar button appears only when a section is selected', async () => {
+        render(<AddScheduleToCalendarModal isOpen={true} onClose={vi.fn()} semesters={mockSemesters} />);
+
+        fireEvent.change(screen.getByLabelText('Select Semester'), { target: { value: 'sem1' } });
+
+        await waitFor(() => {
+            // CS2510 has a pre-selected CRN of 12345 so button should appear
+            expect(screen.getByTestId('add-btn-CS2510-12345')).toBeDefined();
+
+            // CS2500 has NO pre-selected CRN, so button should NOT be there yet
+            expect(screen.queryByTestId(/add-btn-CS2500/)).toBeNull();
+        });
+
+        // Now select a section for CS2500
+        const cs2500Select = screen.getByRole('combobox', { name: 'Select section for CS2500' });
+        fireEvent.change(cs2500Select, { target: { value: '10002' } });
+
+        // Wait for rerender and verify button appeared
+        await waitFor(() => {
+            expect(screen.getByTestId('add-btn-CS2500-10002')).toBeDefined();
+        });
+    });
+});

--- a/components/AddScheduleToCalendarModal.tsx
+++ b/components/AddScheduleToCalendarModal.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { AddToCalendarButton } from './AddToCalendarButton';
+import { fetchCourseCached } from '@/hooks/useSingleCourse';
+import { CourseData } from '@/hooks/useCourseSearch';
+
+export interface CalendarSemester {
+    id: string;
+    name: string;
+    order: number;
+    courses: (string | { courseId: string; crn?: string })[];
+}
+
+interface AddScheduleToCalendarModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    semesters: CalendarSemester[];
+}
+
+export default function AddScheduleToCalendarModal({
+    isOpen,
+    onClose,
+    semesters,
+}: AddScheduleToCalendarModalProps) {
+    const [selectedSemesterId, setSelectedSemesterId] = useState<string>('');
+    const [courseDetails, setCourseDetails] = useState<Map<string, CourseData>>(new Map());
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        if (!isOpen) {
+            setSelectedSemesterId('');
+            setCourseDetails(new Map());
+        }
+    }, [isOpen]);
+
+    const selectedSemester = semesters.find(s => s.id === selectedSemesterId);
+
+    // Only courses that have a specific section (CRN) selected in the plan
+    const scheduledCourses = selectedSemester?.courses
+        .map(c => typeof c === 'string' ? { courseId: c, crn: undefined } : { courseId: c.courseId, crn: c.crn })
+        .filter((c): c is { courseId: string; crn: string } => c.crn !== undefined) || [];
+
+    useEffect(() => {
+        if (!selectedSemesterId || scheduledCourses.length === 0) {
+            setCourseDetails(new Map());
+            return;
+        }
+
+        let isMounted = true;
+        setIsLoading(true);
+
+        const fetchAllCourses = async () => {
+            try {
+                const uniqueCourseIds = Array.from(new Set(scheduledCourses.map(c => c.courseId)));
+                const responses = await Promise.all(
+                    uniqueCourseIds.map(id => fetchCourseCached(id).catch(() => null))
+                );
+
+                if (!isMounted) return;
+
+                const newCourseMap = new Map<string, CourseData>();
+                responses.forEach((data, index) => {
+                    const id = uniqueCourseIds[index];
+                    if (data) {
+                        newCourseMap.set(id, data);
+                    }
+                });
+
+                setCourseDetails(newCourseMap);
+            } finally {
+                if (isMounted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        fetchAllCourses();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [selectedSemesterId, scheduledCourses.length]); // Intentionally omitting full array to avoid loop
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+            <div
+                className="absolute inset-0 bg-gray-500/75 transition-opacity"
+                aria-hidden="true"
+                onClick={onClose}
+            ></div>
+
+                <div className="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto sm:p-6">
+                    <div className="absolute top-0 right-0 pt-4 pr-4">
+                        <button
+                            type="button"
+                            className="bg-white rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                            onClick={onClose}
+                        >
+                            <span className="sr-only">Close</span>
+                            <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                        </button>
+                    </div>
+                    <div className="sm:flex sm:items-start">
+                        <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full">
+                            <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-title">
+                                Add Schedule to Calendar
+                            </h3>
+                            <div className="mt-4">
+                                <label htmlFor="semester-select" className="block text-sm font-medium text-gray-700">
+                                    Select Semester
+                                </label>
+                                <select
+                                    id="semester-select"
+                                    className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+                                    value={selectedSemesterId}
+                                    onChange={(e) => setSelectedSemesterId(e.target.value)}
+                                >
+                                    <option value="" disabled>Select a semester...</option>
+                                    {semesters.map((sem) => (
+                                        <option key={sem.id} value={sem.id}>
+                                            {sem.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            {selectedSemesterId && (
+                                <div className="mt-6">
+                                    <h4 className="text-sm font-medium text-gray-900 mb-2">Courses with selected sections</h4>
+
+                                    {isLoading ? (
+                                        <div className="flex justify-center py-4">
+                                            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-indigo-600"></div>
+                                        </div>
+                                    ) : scheduledCourses.length === 0 ? (
+                                        <p className="text-sm text-gray-500 italic">
+                                            No courses in this semester have a specific section selected. Use Quick Add to add a course and pick a section.
+                                        </p>
+                                    ) : (
+                                        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+                                            {scheduledCourses.map((c, idx) => {
+                                                const courseData = courseDetails.get(c.courseId);
+                                                const section = courseData?.sections?.find(s => s.crn === c.crn);
+
+                                                return (
+                                                    <li key={`${c.courseId}-${idx}`} className="py-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+                                                        <div className="flex-1 min-w-0">
+                                                            <p className="text-sm font-medium text-gray-900 truncate">{c.courseId}</p>
+                                                            {courseData && <p className="text-xs text-gray-500 truncate">{courseData.name}</p>}
+                                                        </div>
+
+                                                        <div className="flex-1 min-w-0">
+                                                            <p className="text-xs text-gray-600">CRN {c.crn}</p>
+                                                            <p className="text-xs text-gray-400">{section?.meetingTimes || 'Schedule TBA'}</p>
+                                                        </div>
+
+                                                        <div className="shrink-0">
+                                                            <AddToCalendarButton
+                                                                courseId={c.courseId}
+                                                                crn={c.crn}
+                                                                courseName={c.courseId}
+                                                            />
+                                                        </div>
+                                                    </li>
+                                                );
+                                            })}
+                                        </ul>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                    <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
+                        <button
+                            type="button"
+                            className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
+                            onClick={onClose}
+                        >
+                            Done
+                        </button>
+                    </div>
+                </div>
+        </div>
+    );
+}

--- a/components/AddSemesterModal.tsx
+++ b/components/AddSemesterModal.tsx
@@ -7,10 +7,11 @@ interface AddSemesterModalProps {
     planId: string | null;
     isOpen: boolean;
     onClose: () => void;
+    addSemester: (name: string, order: number) => Promise<void>;
+    currentSemesterCount: number;
 }
 
-export default function AddSemesterModal({ planId, isOpen, onClose }: AddSemesterModalProps) {
-    const { plan, addSemester } = usePlanDetails(planId);
+export default function AddSemesterModal({ planId, isOpen, onClose, addSemester, currentSemesterCount }: AddSemesterModalProps) {
     const [newSemesterName, setNewSemesterName] = useState('');
     const [isCreatingSem, setIsCreatingSem] = useState(false);
 
@@ -31,7 +32,7 @@ export default function AddSemesterModal({ planId, isOpen, onClose }: AddSemeste
 
         try {
             setIsCreatingSem(true);
-            const order = plan?.semesters ? plan.semesters.length + 1 : 1;
+            const order = currentSemesterCount + 1;
             await addSemester(newSemesterName, order);
             setNewSemesterName('');
             onClose();

--- a/components/AddToCalendarButton.test.tsx
+++ b/components/AddToCalendarButton.test.tsx
@@ -48,7 +48,7 @@ describe('AddToCalendarButton', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Add course schedule to calendar' }));
 
         await waitFor(() => {
-            expect(screen.getByText('Cannot parse schedule')).toBeDefined();
+            expect(screen.getByText('No schedule available')).toBeDefined();
         });
     });
 

--- a/components/AddToCalendarButton.test.tsx
+++ b/components/AddToCalendarButton.test.tsx
@@ -1,0 +1,69 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AddToCalendarButton } from './AddToCalendarButton';
+import { fetchCourseCached } from '@/hooks/useSingleCourse';
+import { useEvents } from '@/hooks/useEvents';
+
+// Mock dependencies
+vi.mock('@/hooks/useSingleCourse', () => ({
+    fetchCourseCached: vi.fn(),
+}));
+
+vi.mock('@/hooks/useEvents', () => ({
+    useEvents: vi.fn(),
+}));
+
+describe('AddToCalendarButton', () => {
+    const mockAddEvent = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (useEvents as any).mockReturnValue({
+            addEvent: mockAddEvent,
+        });
+    });
+
+    test('renders button with correct aria-label', () => {
+        render(<AddToCalendarButton courseId="CS2500" crn="12345" courseName="CS2500" />);
+        expect(screen.getByRole('button', { name: 'Add course schedule to calendar' })).toBeDefined();
+    });
+
+    test('shows error when section is not found', async () => {
+        (fetchCourseCached as any).mockResolvedValue({ sections: [] });
+        render(<AddToCalendarButton courseId="CS2500" crn="12345" courseName="CS2500" />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add course schedule to calendar' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Section not found')).toBeDefined();
+        });
+    });
+
+    test('shows error when schedule cannot be parsed (TBA)', async () => {
+        (fetchCourseCached as any).mockResolvedValue({
+            sections: [{ crn: '12345', meetingTimes: 'TBA', rooms: 'Room 1' }],
+        });
+        render(<AddToCalendarButton courseId="CS2500" crn="12345" courseName="CS2500" />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add course schedule to calendar' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Cannot parse schedule')).toBeDefined();
+        });
+    });
+
+    test('calls addEvent for each parsed day and shows success message', async () => {
+        (fetchCourseCached as any).mockResolvedValue({
+            sections: [{ crn: '12345', meetingTimes: 'MWF 10:30am - 11:35am', rooms: 'Ryder 101' }],
+        });
+        render(<AddToCalendarButton courseId="CS2500" crn="12345" courseName="CS2500" />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add course schedule to calendar' }));
+
+        await waitFor(() => {
+            expect(mockAddEvent).toHaveBeenCalledTimes(3);
+        });
+
+        expect(screen.getByText('Added to calendar!')).toBeDefined();
+    });
+});

--- a/components/AddToCalendarButton.tsx
+++ b/components/AddToCalendarButton.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { CalendarIcon } from '@heroicons/react/24/outline';
+import { fetchCourseCached } from '@/hooks/useSingleCourse';
+import { useEvents } from '@/hooks/useEvents';
+import { parseMeetingTime } from '@/lib/parse-meeting-times';
+import { nextDay, setHours, setMinutes, getDay } from 'date-fns';
+
+const DAY_TO_INDEX: Record<string, 0 | 1 | 2 | 3 | 4 | 5 | 6> = {
+    Sunday: 0,
+    Monday: 1,
+    Tuesday: 2,
+    Wednesday: 3,
+    Thursday: 4,
+    Friday: 5,
+    Saturday: 6,
+};
+
+function getNextDateForDayAndTime(dayName: string, time24h: string): Date {
+    const [hours, minutes] = time24h.split(':').map(Number);
+    const now = new Date();
+    const dayIndex = DAY_TO_INDEX[dayName];
+
+    const targetDate = getDay(now) === dayIndex ? now : nextDay(now, dayIndex);
+    return setMinutes(setHours(targetDate, hours), minutes);
+}
+
+interface AddToCalendarButtonProps {
+    courseId: string;
+    crn: string;
+    courseName: string;
+}
+
+export function AddToCalendarButton({ courseId, crn, courseName }: AddToCalendarButtonProps) {
+    const { addEvent } = useEvents();
+    const [isLoading, setIsLoading] = useState(false);
+    const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+    const [errorMsg, setErrorMsg] = useState('');
+
+    const handleClick = async () => {
+        setIsLoading(true);
+        setStatus('idle');
+        setErrorMsg('');
+
+        try {
+            const course = await fetchCourseCached(courseId);
+            const section = course?.sections?.find((sec: any) => sec.crn === crn);
+
+            if (!section) {
+                setStatus('error');
+                setErrorMsg('Section not found');
+                return;
+            }
+
+            const parsed = parseMeetingTime(section.meetingTimes);
+            if (!parsed) {
+                setStatus('error');
+                setErrorMsg('Cannot parse schedule');
+                return;
+            }
+
+            for (const day of parsed.days) {
+                const start = getNextDateForDayAndTime(day, parsed.startTime).toISOString();
+                const end = getNextDateForDayAndTime(day, parsed.endTime).toISOString();
+
+                await addEvent({
+                    title: courseName,
+                    startTime: start,
+                    endTime: end,
+                    location: section.rooms || '',
+                    color: 'blue',
+                });
+            }
+
+            setStatus('success');
+            setTimeout(() => {
+                setStatus('idle');
+            }, 2000);
+        } catch (error) {
+            console.error(error);
+            setStatus('error');
+            setErrorMsg('Failed to add events');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className="flex items-center space-x-2 mt-2">
+            <button
+                onClick={handleClick}
+                disabled={isLoading || status === 'success'}
+                aria-label="Add course schedule to calendar"
+                className="flex items-center space-x-1 text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded hover:bg-blue-200 disabled:opacity-50 transition-colors"
+            >
+                <CalendarIcon className="w-4 h-4" />
+                <span>{isLoading ? 'Adding...' : 'Add to Calendar'}</span>
+            </button>
+            {status === 'success' && <span className="text-xs text-green-600 font-medium">Added to calendar!</span>}
+            {status === 'error' && <span className="text-xs text-red-600 font-medium">{errorMsg}</span>}
+        </div>
+    );
+}

--- a/components/AddToCalendarButton.tsx
+++ b/components/AddToCalendarButton.tsx
@@ -53,24 +53,30 @@ export function AddToCalendarButton({ courseId, crn, courseName }: AddToCalendar
                 return;
             }
 
-            const parsed = parseMeetingTime(section.meetingTimes);
-            if (!parsed) {
+            const parsedSchedules = parseMeetingTime(section.meetingTimes);
+            if (!parsedSchedules) {
                 setStatus('error');
-                setErrorMsg('Cannot parse schedule');
+                if (section.meetingTimes?.trim().toUpperCase() === 'TBA') {
+                    setErrorMsg('No schedule available');
+                } else {
+                    setErrorMsg('Cannot parse schedule');
+                }
                 return;
             }
 
-            for (const day of parsed.days) {
-                const start = getNextDateForDayAndTime(day, parsed.startTime).toISOString();
-                const end = getNextDateForDayAndTime(day, parsed.endTime).toISOString();
+            for (const parsed of parsedSchedules) {
+                for (const day of parsed.days) {
+                    const start = getNextDateForDayAndTime(day, parsed.startTime).toISOString();
+                    const end = getNextDateForDayAndTime(day, parsed.endTime).toISOString();
 
-                await addEvent({
-                    title: courseName,
-                    startTime: start,
-                    endTime: end,
-                    location: section.rooms || '',
-                    color: 'blue',
-                });
+                    await addEvent({
+                        title: courseName,
+                        startTime: start,
+                        endTime: end,
+                        location: section.rooms || '',
+                        color: 'blue',
+                    });
+                }
             }
 
             setStatus('success');

--- a/components/CourseMiniCard.test.tsx
+++ b/components/CourseMiniCard.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CourseMiniCard from './CourseMiniCard';
+import { useSingleCourse } from '@/hooks/useSingleCourse';
+
+// Mock useSingleCourse
+vi.mock('@/hooks/useSingleCourse', () => ({
+    useSingleCourse: vi.fn(),
+}));
+
+// Mock @/lib/firebase
+vi.mock('@/lib/firebase', () => ({
+    auth: {},
+    db: {},
+}));
+
+describe('CourseMiniCard', () => {
+    const mockCourse = {
+        id: 'CS3500',
+        subject: 'CS',
+        number: '3500',
+        name: 'Object-Oriented Design',
+        creditHours: 4,
+        prereqs: ['CS1800', 'CS2500'],
+        coreqs: ['CS2501'],
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('shows missing prereq badge when one prereq is missing', () => {
+        vi.mocked(useSingleCourse).mockReturnValue({
+            course: mockCourse as any,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <CourseMiniCard
+                courseId="CS3500"
+                currentSemesterOrder={3}
+                allPlanCourses={[
+                    { courseId: 'CS2500', semesterOrder: 1 } // CS1800 is missing
+                ]}
+            />
+        );
+
+        const prereqBadge = screen.getByText('Prereq needed: CS1800');
+        expect(prereqBadge).toBeInTheDocument();
+    });
+
+    it('shows missing prereq badge when multiple prereqs are missing', () => {
+        vi.mocked(useSingleCourse).mockReturnValue({
+            course: mockCourse as any,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <CourseMiniCard
+                courseId="CS3500"
+                currentSemesterOrder={3}
+                allPlanCourses={[]} // Both missing
+            />
+        );
+
+        const prereqBadge = screen.getByText('Prereq needed: CS1800, CS2500');
+        expect(prereqBadge).toBeInTheDocument();
+        expect(prereqBadge).toHaveAttribute('aria-label', 'Missing prerequisites: CS1800, CS2500');
+    });
+
+    it('shows no prereq badge when all prereqs are satisfied', () => {
+        vi.mocked(useSingleCourse).mockReturnValue({
+            course: mockCourse as any,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <CourseMiniCard
+                courseId="CS3500"
+                currentSemesterOrder={3}
+                allPlanCourses={[
+                    { courseId: 'CS1800', semesterOrder: 1 },
+                    { courseId: 'CS2500', semesterOrder: 2 },
+                ]}
+            />
+        );
+
+        expect(screen.queryByText(/Prereq needed/)).not.toBeInTheDocument();
+    });
+
+    it('shows missing coreq badge when coreq is missing', () => {
+        vi.mocked(useSingleCourse).mockReturnValue({
+            course: mockCourse as any,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <CourseMiniCard
+                courseId="CS3500"
+                currentSemesterOrder={3}
+                allPlanCourses={[
+                    { courseId: 'CS1800', semesterOrder: 1 },
+                    { courseId: 'CS2500', semesterOrder: 2 },
+                    // CS2501 coreq missing
+                ]}
+            />
+        );
+
+        const coreqBadge = screen.getByText('Coreq needed: CS2501');
+        expect(coreqBadge).toBeInTheDocument();
+    });
+
+    it('shows no warning badges when course has no prereqs/coreqs', () => {
+        vi.mocked(useSingleCourse).mockReturnValue({
+            course: {
+                ...mockCourse,
+                prereqs: [],
+                coreqs: [],
+            } as any,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <CourseMiniCard
+                courseId="CS3500"
+                currentSemesterOrder={3}
+                allPlanCourses={[]}
+            />
+        );
+
+        expect(screen.queryByText(/Prereq needed/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Coreq needed/)).not.toBeInTheDocument();
+    });
+
+    it('badge has correct aria-label', () => {
+        vi.mocked(useSingleCourse).mockReturnValue({
+            course: mockCourse as any,
+            loading: false,
+            error: null,
+        });
+
+        render(
+            <CourseMiniCard
+                courseId="CS3500"
+                currentSemesterOrder={3}
+                allPlanCourses={[
+                    { courseId: 'CS2500', semesterOrder: 2 } // CS1800 is missing
+                ]}
+            />
+        );
+
+        const prereqBadge = screen.getByText('Prereq needed: CS1800');
+        expect(prereqBadge).toHaveAttribute('aria-label', 'Missing prerequisites: CS1800');
+    });
+});

--- a/components/CourseMiniCard.tsx
+++ b/components/CourseMiniCard.tsx
@@ -35,11 +35,11 @@ export default function CourseMiniCard({ courseId, crn, onRemove, allPlanCourses
         );
     }
 
-    const hasMissingPrereqs = course && allPlanCourses && currentSemesterOrder ?
-        course.prereqs.some(pr => !allPlanCourses.some(c => c.courseId === pr && c.semesterOrder < currentSemesterOrder)) : false;
+    const missingPrereqs: string[] = course && allPlanCourses && currentSemesterOrder ?
+        course.prereqs.filter(pr => !allPlanCourses.some(c => c.courseId === pr && c.semesterOrder < currentSemesterOrder)) : [];
 
-    const hasMissingCoreqs = course && allPlanCourses && currentSemesterOrder ?
-        course.coreqs.some(cr => !allPlanCourses.some(c => c.courseId === cr && c.semesterOrder <= currentSemesterOrder)) : false;
+    const missingCoreqs: string[] = course && allPlanCourses && currentSemesterOrder ?
+        course.coreqs.filter(cr => !allPlanCourses.some(c => c.courseId === cr && c.semesterOrder <= currentSemesterOrder)) : [];
 
     return (
         <div className="group relative flex flex-col p-3 bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 transition-colors">
@@ -72,14 +72,22 @@ export default function CourseMiniCard({ courseId, crn, onRemove, allPlanCourses
 
             <div className="flex justify-between items-end mt-1">
                 <div className="flex flex-col gap-1 items-start">
-                    {hasMissingPrereqs && (
-                        <span className="text-[10px] font-bold text-orange-600 bg-orange-50 border border-orange-200 px-1.5 py-0.5 rounded shadow-sm">
-                            Missing Prereq
+                    {missingPrereqs.length > 0 && (
+                        <span
+                            className="text-[10px] font-bold text-orange-600 bg-orange-50 border border-orange-200 px-1.5 py-0.5 rounded shadow-sm"
+                            aria-label={`Missing prerequisites: ${missingPrereqs.join(", ")}`}
+                            title={`Prereq needed: ${missingPrereqs.join(", ")}`}
+                        >
+                            Prereq needed: {missingPrereqs.join(", ")}
                         </span>
                     )}
-                    {hasMissingCoreqs && (
-                        <span className="text-[10px] font-bold text-blue-600 bg-blue-50 border border-blue-200 px-1.5 py-0.5 rounded shadow-sm">
-                            Coreq not in this semester
+                    {missingCoreqs.length > 0 && (
+                        <span
+                            className="text-[10px] font-bold text-blue-600 bg-blue-50 border border-blue-200 px-1.5 py-0.5 rounded shadow-sm"
+                            aria-label={`Missing corequisites: ${missingCoreqs.join(", ")}`}
+                            title={`Coreq needed: ${missingCoreqs.join(", ")}`}
+                        >
+                            Coreq needed: {missingCoreqs.join(", ")}
                         </span>
                     )}
                 </div>

--- a/components/QuickAddModal.tsx
+++ b/components/QuickAddModal.tsx
@@ -10,9 +10,11 @@ interface QuickAddModalProps {
     planId: string | null;
     isOpen: boolean;
     onClose: () => void;
+    addCourseToSemester: (semId: string, courseId: string, crn?: string) => Promise<void>;
+    semesters: Array<{ id: string; name: string; order: number; courses: (string | { courseId: string; crn?: string })[] }>;
 }
 
-export default function QuickAddModal({ planId, isOpen, onClose }: QuickAddModalProps) {
+export default function QuickAddModal({ planId, isOpen, onClose, addCourseToSemester, semesters }: QuickAddModalProps) {
     const { query, setQuery, courses, loading: searchLoading, error: searchError } = useCourseSearch();
     const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
 
@@ -85,6 +87,8 @@ export default function QuickAddModal({ planId, isOpen, onClose }: QuickAddModal
                                     isExpanded={selectedCourseId === course.id}
                                     onToggle={() => setSelectedCourseId(selectedCourseId === course.id ? null : course.id)}
                                     planId={planId}
+                                    addCourseToSemester={addCourseToSemester}
+                                    semesters={semesters}
                                 />
                             ))}
                         </div>
@@ -95,7 +99,7 @@ export default function QuickAddModal({ planId, isOpen, onClose }: QuickAddModal
     );
 }
 
-function CourseResultRow({ course, isExpanded, onToggle, planId }: { course: CourseData; isExpanded: boolean; onToggle: () => void; planId: string | null; }) {
+function CourseResultRow({ course, isExpanded, onToggle, planId, addCourseToSemester, semesters }: { course: CourseData; isExpanded: boolean; onToggle: () => void; planId: string | null; addCourseToSemester: (semId: string, courseId: string, crn?: string) => Promise<void>; semesters: Array<{ id: string; name: string; order: number; courses: (string | { courseId: string; crn?: string })[] }>; }) {
     return (
         <div className="border border-gray-200 rounded-lg overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow">
             <button
@@ -115,16 +119,15 @@ function CourseResultRow({ course, isExpanded, onToggle, planId }: { course: Cou
 
             {isExpanded && (
                 <div className="border-t border-gray-100 bg-gray-50 p-4 animate-in slide-in-from-top-2 duration-300 ease-in-out">
-                    <CourseDetailsSection courseId={course.id} planId={planId} />
+                    <CourseDetailsSection courseId={course.id} addCourseToSemester={addCourseToSemester} semesters={semesters} />
                 </div>
             )}
         </div>
     );
 }
 
-function CourseDetailsSection({ courseId, planId }: { courseId: string; planId: string | null; }) {
+function CourseDetailsSection({ courseId, addCourseToSemester, semesters }: { courseId: string; addCourseToSemester: (semId: string, courseId: string, crn?: string) => Promise<void>; semesters: Array<{ id: string; name: string; order: number; courses: (string | { courseId: string; crn?: string })[] }>; }) {
     const { course, loading, error } = useSingleCourse(courseId);
-    const { plan, addCourseToSemester } = usePlanDetails(planId);
 
     // local state for inline semester selection
     const [selectedCrn, setSelectedCrn] = useState<string | null>(null);
@@ -150,8 +153,6 @@ function CourseDetailsSection({ courseId, planId }: { courseId: string; planId: 
     if (loading) return <div className="text-gray-500 text-sm py-4 flex items-center justify-center gap-2"><div className="animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-600"></div> Loading sections...</div>;
     if (error || !course) return <div className="text-red-500 text-sm py-2 px-3 bg-red-50 rounded border border-red-100">Failed to load course details.</div>;
     if (!course.sections || course.sections.length === 0) return <div className="text-gray-500 text-sm py-3 italic bg-white rounded border border-gray-200 px-4 text-center">No sections available for {courseId}.</div>;
-
-    const semesters = plan?.semesters || [];
 
     return (
         <div className="flex flex-col gap-3">
@@ -214,8 +215,8 @@ function CourseDetailsSection({ courseId, planId }: { courseId: string; planId: 
                                     onClick={() => setSelectedCrn(sec.crn)}
                                     disabled={isAdded}
                                     className={`shrink-0 px-4 py-2 text-sm font-medium rounded-md border transition-colors ${isAdded
-                                            ? 'bg-gray-50 text-gray-400 border-gray-200 cursor-not-allowed'
-                                            : 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100 border-indigo-200'
+                                        ? 'bg-gray-50 text-gray-400 border-gray-200 cursor-not-allowed'
+                                        : 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100 border-indigo-200'
                                         }`}
                                 >
                                     {isAdded ? 'Added' : 'Add to Plan'}

--- a/docs/logs/log-05.md
+++ b/docs/logs/log-05.md
@@ -1,23 +1,31 @@
-# Log 05: Fix React Hydration Mismatch
-**Date:** 2026-03-03
-**Timestamp:** 09:03:00-05:00
-**Author:** Antigravity Agent
-**Related Bug:** Local Dev Environment Hydration Error
+---
+id: log-05
+timestamp: 2026-03-05T08:23:00-08:00
+description: "feat(plans): show specific missing course IDs in prereq/coreq warnings"
+issue: "#5"
+---
 
-## Overview
-Fixed a `Text content did not match` / Hydration Mismatch error thrown by React 18 / Next.js 14 during local development on the `<body>` element.
+# Change Log
 
-## Root Cause
-Browser extensions (e.g., password managers, Grammarly) inject attributes or nodes into the `<body>` tag before React completes hydration on the client. React expects the client HTML to exactly match the server-rendered HTML. When an extension modifies the body tag before React takes over, React throws a severe hydration mismatch error.
+## Modified
+* `components/CourseMiniCard.tsx`
+  * Replaced boolean flags for missing prereqs and coreqs with arrays of missing course IDs.
+  * Updated warning badges to display the specific missing course IDs (e.g., "Prereq needed: CS1800, CS2500") instead of a generic "Missing Prereq" message.
+  * Added `aria-label` for screen readers (e.g., "Missing prerequisites: CS1800, CS2500").
+  * Added `title` attribute for native tooltips.
+  * Preserved existing orange/blue styling for soft warnings.
 
-## Key Changes
-- **app/layout.tsx:** Added the `suppressHydrationWarning` prop to the HTML `<body>` tag. As documented by Next.js, this explicitly signals React to ignore attribute mismatches on the body tag (which is exactly what extensions modify). This safely prevents the crash without disabling strict mode or breaking actual app tree hydration.
+## Added
+* `components/CourseMiniCard.test.tsx`
+  * Added test file for `CourseMiniCard.tsx`.
+  * Covered 6 scenarios:
+    1. One prereq missing.
+    2. Multiple prereqs missing.
+    3. All prereqs satisfied.
+    4. Missing coreq.
+    5. No prereqs/coreqs required.
+    6. Verify correct aria-label.
+  * Used `vi.mock` for `useSingleCourse` and `@/lib/firebase`.
 
-
-## Testing Instructions (Development)
-**How to test interactively:** Run `npm run dev` and open the application with various browser extensions (like password managers) enabled. Check the developer console to confirm that the "React Hydration Mismatch" error on the `<body>` tag no longer appears.
-
-**Automated Tests Added:**
-- **What:** N/A (Configuration-only fix).
-- **Reasoning:** Fixing the layout's HTML hydration mismatch via Next.js `suppressHydrationWarning` prevents dev-environment crashes.
-- **How to run:** Visual confirmation inside browser DevTools.
+## Notes
+Improves accessibility and UX by helping students know exactly which courses they need to add to their degree plan to fix warnings. Does not block students from progressing (soft warnings only).

--- a/docs/logs/log-06.md
+++ b/docs/logs/log-06.md
@@ -1,0 +1,13 @@
+# Log 06
+- ID: log-06
+- Timestamp: 2026-03-04T21:33:00-08:00
+- Description: Fixed calendar page bugs and completed event CRUD for Weekly Calendar view.
+  - Fixed dark background issue in global CSS.
+  - Rewrote calendar component to support full 24-hour vertical timeline.
+  - Replaced date-of-week logic with absolute local Dates to fix timezone overflow issues.
+  - Implemented visual overlap detection for colliding events.
+  - Added new event form inputs: Location and Date.
+  - Hooked up `updateEvent` PUT API request.
+  - Fixed typing issues across all `hooks/useEvents.ts` and API routes to strictly use `unknown`.
+  - Added guard to filter corrupted empty events returned from DB.
+- Issue: #6

--- a/docs/logs/log-06b.md
+++ b/docs/logs/log-06b.md
@@ -1,0 +1,38 @@
+# Log 06b: Fix Plan Display Bugs and TypeScript Violations
+
+**ID:** log-06b
+**Date:** 2026-03-05
+**Author:** Joythish Sprint 1 Team
+
+## Overview
+Fixed display bugs related to `semesterCount` on the dashboard and fixed TypeScript `any` type violations in plan hooks. Also addressed UI not updating correctly after adding a course.
+
+## Changes
+
+1. **Bug 1: Dashboard shows "0 Semesters" for all plans**
+   - *File modified:* `app/api/v1/plans/route.ts`
+   - *Fix:* Updated the GET route handler to iterate through each plan document from `plansSnapshot`, subquery the `semesters` subcollection for each to retrieve the exact count, and return `semesterCount` in the response payload instead of an empty `semesters` array.
+   - *File modified:* `app/dashboard/page.tsx`
+   - *Fix:* Updated the rendered metric from `{plan.semesters?.length || 0}` to `{plan.semesterCount || 0}`.
+   - *File modified:* `hooks/usePlans.ts`
+   - *Fix:* Updated the `Plan` interface payload to use `semesterCount?: number` to safely encompass this change on the frontend.
+
+2. **Bug 2: Adding courses requires page refresh**
+   - *File modified:* `hooks/usePlanDetails.ts`
+   - *Fix:* In `addCourseToSemester`, after a successful POST request to the API, added an `await fetchPlanDetails()` call so the component cleanly synchronizes with data source changes.
+
+3. **Bug 3: React Hook state duplication in Modals**
+   - *File modified:* `app/plans/[planId]/page.tsx`, `components/AddSemesterModal.tsx`, `components/QuickAddModal.tsx`
+   - *Fix:* `AddSemesterModal` and `QuickAddModal` previously initialized their own instances of `usePlanDetails(planId)`, separating their internal states from the main `PlanDetailsPage`. Addressed this anti-pattern by destructuring `addSemester` and `addCourseToSemester` in the `PlanDetailsPage` parent component and prop-drilling them down to the Modals so `fetchPlanDetails` syncs correctly with the UI upon mutations.
+
+4. **TypeScript Violation fixes (No `any` types)**
+   - *File modified:* `hooks/usePlanDetails.ts`, `hooks/usePlans.ts`
+   - *Fix:* Replaced all catch blocks defining `catch (err: any)` to strongly typed error handlers: `catch (err: unknown) { setError(err instanceof Error ? err.message : 'Unknown error'); }`
+   - *Fix:* Replaced `createdAt?: any` in the `Plan` interface with strongly typed object literal representing Firestore timestamps, `{ seconds: number; nanoseconds: number } | string`.
+
+## Verification
+- Unit tests run with `npm run test` (10 files, 40 tests passed successfully).
+- Next.js application built normally with `npm run build`.
+- Executed `grep -r ": any"` on `hooks/usePlans.ts` and `hooks/usePlanDetails.ts` providing 0 hits.
+- Verified semester counts explicitly render accurately on the Plans dashboard.
+- Verified dynamic course addition synchronizes and rerenders upon successful additions without needing to manual refresh.

--- a/docs/logs/log-07.md
+++ b/docs/logs/log-07.md
@@ -1,0 +1,14 @@
+# Log 07
+- ID: log-07
+- Timestamp: 2026-03-05T07:13:00-08:00
+- Description: Implemented Add to Calendar functionality from degree plan.
+  - Created `parseMeetingTime` utility to convert course section meeting strings into usable data (e.g. `MWF 10:30am - 11:35am`).
+  - Wrote comprehensive unit tests for `parseMeetingTime`.
+  - Built `AddToCalendarButton` component invoking the `useEvents` hook to push events to Firestore.
+  - Replaced missing `lucide-react` dependency with `@heroicons/react` in component.
+  - Installed `date-fns` for time calculation in component.
+  - Wrote unit tests for `AddToCalendarButton` ensuring proper behavior when adding schedules.
+  - Built `AddScheduleToCalendarModal` to organize the UI cleanly next to other plan actions.
+  - Removed inline calendar buttons from `CourseMiniCard`.
+  - Fixed parsing bug in `parseMeetingTime` to handle extra spaces separating AM/PM and days (e.g. `M W R 1:35 pm - 2:40 pm`).
+- Issue: #7

--- a/docs/logs/log-09.md
+++ b/docs/logs/log-09.md
@@ -1,0 +1,14 @@
+# Log 09: Plan Rename Capability
+
+- **Date:** 2026-03-05
+- **Issue:** #9
+- **Description:** Added the ability to rename degree plans on the plans dashboard.
+
+## Changes Made
+1. **API route (`app/api/v1/plans/[planId]/route.ts`)**: Added `PUT` handler to update the `name` and `updatedAt` fields of a plan document in Firestore.
+2. **Hook (`hooks/usePlans.ts`)**: Added `renamePlan` function to the `usePlans` hook, calling the new `PUT` endpoint and performing an optimistic UI update.
+3. **UI (`app/plans/page.tsx`)**: Added inline renaming capability directly on the plan items instead of a separate modal view. Implemented input validation and error handling alongside the "Save" and "Cancel" capabilities.
+
+## Technical Details
+- Added state variables `renamingId`, `renameValue`, and `isRenaming`.
+- Ensured all variables are properly typed. No `any` types were used as per style constraints.

--- a/docs/logs/log-36.md
+++ b/docs/logs/log-36.md
@@ -1,0 +1,14 @@
+---
+id: 36
+date: "2026-03-05T13:48:00-05:00"
+type: fix
+scope: scraper
+description: "Fix scraper logic to correctly extract active days from text-neu9 class"
+issue: ""
+---
+
+# Changes
+- Modified `scripts/scrape-courses.ts` meeting extraction to evaluate the DOM structure.
+- Instead of relying on raw text, the script now iterates over the target day spans and strictly looks for `text-neu9` (bold text) to map the active days.
+- Added mapped conversion to accurately extract Tuesday (`T`) and Thursday (`Th`).
+- Added multi-meeting time support within a single cell, grouping days and times correctly per section (preventing mashed text such as `Th 2:50pm — 4:30pmMTWTF11:45am — 1:25pm`).

--- a/docs/logs/log-37.md
+++ b/docs/logs/log-37.md
@@ -1,0 +1,16 @@
+---
+id: 37
+date: "2026-03-05T14:41:26-05:00"
+type: fix
+scope: calendar
+description: "Fix Plan-to-Calendar parsing for multiple meeting schedules and TBA fallback"
+issue: "7,8"
+---
+
+# Changes
+- Refactored `lib/parse-meeting-times.ts` to split incoming schedule strings by `;` to natively support processing of multiple subgroups per course (e.g. Lecture and Lab times).
+- Updated parsing logic to handle comma-separated days (`M,W,Th`) replacing tight regex loops. Built fallback for traditional tight `MTWRF` spacing patterns.
+- Transitioned `parseMeetingTime` to return an array `ParsedMeetingTime[]` instead of a singular object.
+- Re-architected `components/AddToCalendarButton.tsx` consumption loop to parse and queue multiple sequential subgroups for `addEvent`.
+- Added specific soft-landing logic inside `AddToCalendarButton.tsx` to trap `TBA` strings and throw a cleaner non-parsing "No schedule available" message instead of "Cannot parse schedule".
+- Converted `parse-meeting-times.test.ts` and `AddScheduleToCalendarModal.test.tsx` logic to align with component regressions.

--- a/hooks/useEvents.test.ts
+++ b/hooks/useEvents.test.ts
@@ -1,0 +1,144 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useEvents } from './useEvents';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as useAuthHook from '@/hooks/useAuth';
+
+vi.mock('@/lib/firebase', () => ({
+    auth: {}
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('useEvents Hook', () => {
+    const mockGetIdToken = vi.fn().mockResolvedValue('mock-token');
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(useAuthHook, 'useAuth').mockReturnValue({
+            user: { uid: 'user123', getIdToken: mockGetIdToken },
+            loading: false,
+            error: null
+        } as unknown as ReturnType<typeof useAuthHook.useAuth>);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('addEvent calls POST with correct URL, body, and Authorization header', async () => {
+        // Initial fetch mock
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: [] })
+        });
+
+        const { result } = renderHook(() => useEvents());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const newEvent = { title: 'New Event', startTime: '10:00', endTime: '11:00', location: 'Here', color: 'blue' };
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: { id: 'evt1', ...newEvent } })
+        });
+
+        await act(async () => {
+            await result.current.addEvent(newEvent);
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/v1/events', expect.objectContaining({
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer mock-token'
+            },
+            body: JSON.stringify(newEvent)
+        }));
+
+        expect(result.current.events).toEqual([{ id: 'evt1', ...newEvent }]);
+    });
+
+    it('updateEvent calls PUT with correct URL, body, and auth header', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: [{ id: 'evt1', title: 'Old Event' }] })
+        });
+
+        const { result } = renderHook(() => useEvents());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        const updateData = { title: 'Updated Event' };
+
+        // Update mock
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: { id: 'evt1', title: 'Updated Event' } })
+        });
+
+        // Refetch mock trigger by updateEvent calling fetchEvents again
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: [{ id: 'evt1', title: 'Updated Event' }] })
+        });
+
+        await act(async () => {
+            await result.current.updateEvent('evt1', updateData);
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/v1/events/evt1', expect.objectContaining({
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Bearer mock-token'
+            },
+            body: JSON.stringify(updateData)
+        }));
+
+        expect(result.current.events).toEqual([{ id: 'evt1', title: 'Updated Event' }]);
+    });
+
+    it('deleteEvent calls DELETE with correct URL and auth header', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: [{ id: 'evt1', title: 'To Delete' }] })
+        });
+
+        const { result } = renderHook(() => useEvents());
+        await waitFor(() => expect(result.current.events).toHaveLength(1));
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: { success: true } })
+        });
+
+        await act(async () => {
+            await result.current.deleteEvent('evt1');
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/v1/events/evt1', expect.objectContaining({
+            method: 'DELETE',
+            headers: {
+                'Authorization': 'Bearer mock-token'
+            }
+        }));
+
+        expect(result.current.events).toHaveLength(0);
+    });
+
+    it('methods handle errors correctly', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({ data: [] })
+        });
+
+        const { result } = renderHook(() => useEvents());
+        await waitFor(() => expect(result.current.loading).toBe(false));
+
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            json: async () => ({ error: { message: 'Failed to add event' } })
+        });
+
+        await expect(result.current.addEvent({ title: 'Fail' } as unknown as Parameters<ReturnType<typeof useEvents>['addEvent']>[0])).rejects.toThrow('Failed to add event');
+    });
+});

--- a/hooks/useEvents.ts
+++ b/hooks/useEvents.ts
@@ -35,9 +35,10 @@ export function useEvents() {
             if (!res.ok) throw new Error(data.error?.message || 'Failed to fetch events');
 
             setEvents(data.data || []);
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Events fetch error:', err);
-            setError(err.message || 'Failed to fetch events');
+            const message = err instanceof Error ? err.message : 'Failed to fetch events';
+            setError(message);
         } finally {
             setLoading(false);
         }
@@ -67,8 +68,32 @@ export function useEvents() {
 
             setEvents(prev => [...prev, data.data]);
             return data.data;
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Failed to add event:', err);
+            throw err;
+        }
+    };
+
+    const updateEvent = async (eventId: string, eventData: Partial<EventItem>) => {
+        if (!user) throw new Error("Must be logged in to update an event");
+        try {
+            const token = await user.getIdToken();
+            const res = await fetch(`/api/v1/events/${eventId}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+                body: JSON.stringify(eventData)
+            });
+
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error?.message || 'Failed to update event');
+
+            await fetchEvents();
+            return data.data;
+        } catch (err: unknown) {
+            console.error('Failed to update event:', err);
             throw err;
         }
     };
@@ -88,11 +113,11 @@ export function useEvents() {
             if (!res.ok) throw new Error(data.error?.message || 'Failed to delete event');
 
             setEvents(prev => prev.filter(e => e.id !== eventId));
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Failed to delete event:', err);
             throw err;
         }
     };
 
-    return { events, loading, error, addEvent, deleteEvent, refreshEvents: fetchEvents };
+    return { events, loading, error, addEvent, updateEvent, deleteEvent, refreshEvents: fetchEvents };
 }

--- a/hooks/usePlanDetails.ts
+++ b/hooks/usePlanDetails.ts
@@ -38,7 +38,8 @@ export function usePlanDetails(planId: string | null) {
             const response = await fetch(`/api/v1/plans/${planId}`, {
                 headers: {
                     Authorization: `Bearer ${token}`
-                }
+                },
+                cache: 'no-store'
             });
 
             if (!response.ok) {
@@ -48,8 +49,8 @@ export function usePlanDetails(planId: string | null) {
 
             const data = await response.json();
             setPlan(data.data as DetailedPlan);
-        } catch (err: any) {
-            setError(err.message);
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Unknown error');
         } finally {
             setLoading(false);
         }
@@ -116,6 +117,8 @@ export function usePlanDetails(planId: string | null) {
             const data = await response.json();
             throw new Error(data.error?.message || 'Failed to add course');
         }
+
+        await fetchPlanDetails();
     };
 
     const removeCourseFromSemester = async (semId: string, courseId: string) => {

--- a/hooks/usePlans.ts
+++ b/hooks/usePlans.ts
@@ -4,8 +4,8 @@ import { useAuth } from '@/hooks/useAuth';
 export interface Plan {
     id: string;
     name: string;
-    createdAt?: any;
-    semesters?: any[];
+    createdAt?: { seconds: number; nanoseconds: number } | string;
+    semesterCount?: number;
 }
 
 export function usePlans() {
@@ -28,7 +28,8 @@ export function usePlans() {
             const response = await fetch('/api/v1/plans', {
                 headers: {
                     Authorization: `Bearer ${token}`
-                }
+                },
+                cache: 'no-store'
             });
 
             if (!response.ok) {
@@ -38,8 +39,8 @@ export function usePlans() {
 
             const data = await response.json();
             setPlans(data.data || []);
-        } catch (err: any) {
-            setError(err.message);
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Unknown error');
         } finally {
             setLoading(false);
         }

--- a/hooks/usePlans.ts
+++ b/hooks/usePlans.ts
@@ -92,5 +92,25 @@ export function usePlans() {
         setPlans(prev => prev.filter(p => p.id !== planId));
     };
 
-    return { plans, loading: loading || authLoading, error, createPlan, deletePlan };
+    const renamePlan = async (planId: string, newName: string): Promise<void> => {
+        if (!user) throw new Error("Must be logged in to rename a plan.");
+        const token = await user.getIdToken();
+        const response = await fetch(`/api/v1/plans/${planId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify({ name: newName })
+        });
+
+        if (!response.ok) {
+            const data = await response.json();
+            throw new Error(data.error?.message || 'Failed to rename plan');
+        }
+
+        setPlans(prev => prev.map(p => p.id === planId ? { ...p, name: newName } : p));
+    };
+
+    return { plans, loading: loading || authLoading, error, createPlan, deletePlan, renamePlan };
 }

--- a/lib/parse-meeting-times.test.ts
+++ b/lib/parse-meeting-times.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'vitest';
+import { parseMeetingTime } from './parse-meeting-times';
+
+describe('parseMeetingTime', () => {
+    test('parses MWF with space', () => {
+        expect(parseMeetingTime('MWF 10:30am - 11:35am')).toEqual({
+            days: ['Monday', 'Wednesday', 'Friday'],
+            startTime: '10:30',
+            endTime: '11:35',
+        });
+    });
+
+    test('parses TR', () => {
+        expect(parseMeetingTime('TR 1:35pm - 3:15pm')).toEqual({
+            days: ['Tuesday', 'Thursday'],
+            startTime: '13:35',
+            endTime: '15:15',
+        });
+    });
+
+    test('parses space before am/pm and spaced days', () => {
+        expect(parseMeetingTime('M W R 1:35 pm - 2:40 pm')).toEqual({
+            days: ['Monday', 'Wednesday', 'Thursday'],
+            startTime: '13:35',
+            endTime: '14:40',
+        });
+    });
+
+    test('parses no space between days and time', () => {
+        expect(parseMeetingTime('MWF9:00am - 10:50am')).toEqual({
+            days: ['Monday', 'Wednesday', 'Friday'],
+            startTime: '09:00',
+            endTime: '10:50',
+        });
+    });
+
+    test('parses single day', () => {
+        expect(parseMeetingTime('M 9:00am - 10:00am')).toEqual({
+            days: ['Monday'],
+            startTime: '09:00',
+            endTime: '10:00',
+        });
+    });
+
+    test('handles 12:00pm noon correctly', () => {
+        expect(parseMeetingTime('M 12:00pm - 1:00pm')).toEqual({
+            days: ['Monday'],
+            startTime: '12:00',
+            endTime: '13:00',
+        });
+    });
+
+    test('handles 12:30am correctly', () => {
+        expect(parseMeetingTime('T 12:30am - 2:00am')).toEqual({
+            days: ['Tuesday'],
+            startTime: '00:30',
+            endTime: '02:00',
+        });
+    });
+
+    test('returns null for TBA', () => {
+        expect(parseMeetingTime('TBA')).toBeNull();
+    });
+
+    test('returns null for empty string', () => {
+        expect(parseMeetingTime('')).toBeNull();
+    });
+
+    test('returns null for invalid format', () => {
+        expect(parseMeetingTime('Invalid String')).toBeNull();
+    });
+});

--- a/lib/parse-meeting-times.test.ts
+++ b/lib/parse-meeting-times.test.ts
@@ -3,59 +3,59 @@ import { parseMeetingTime } from './parse-meeting-times';
 
 describe('parseMeetingTime', () => {
     test('parses MWF with space', () => {
-        expect(parseMeetingTime('MWF 10:30am - 11:35am')).toEqual({
+        expect(parseMeetingTime('MWF 10:30am - 11:35am')).toEqual([{
             days: ['Monday', 'Wednesday', 'Friday'],
             startTime: '10:30',
             endTime: '11:35',
-        });
+        }]);
     });
 
     test('parses TR', () => {
-        expect(parseMeetingTime('TR 1:35pm - 3:15pm')).toEqual({
+        expect(parseMeetingTime('TR 1:35pm - 3:15pm')).toEqual([{
             days: ['Tuesday', 'Thursday'],
             startTime: '13:35',
             endTime: '15:15',
-        });
+        }]);
     });
 
     test('parses space before am/pm and spaced days', () => {
-        expect(parseMeetingTime('M W R 1:35 pm - 2:40 pm')).toEqual({
+        expect(parseMeetingTime('M W R 1:35 pm - 2:40 pm')).toEqual([{
             days: ['Monday', 'Wednesday', 'Thursday'],
             startTime: '13:35',
             endTime: '14:40',
-        });
+        }]);
     });
 
     test('parses no space between days and time', () => {
-        expect(parseMeetingTime('MWF9:00am - 10:50am')).toEqual({
+        expect(parseMeetingTime('MWF9:00am - 10:50am')).toEqual([{
             days: ['Monday', 'Wednesday', 'Friday'],
             startTime: '09:00',
             endTime: '10:50',
-        });
+        }]);
     });
 
     test('parses single day', () => {
-        expect(parseMeetingTime('M 9:00am - 10:00am')).toEqual({
+        expect(parseMeetingTime('M 9:00am - 10:00am')).toEqual([{
             days: ['Monday'],
             startTime: '09:00',
             endTime: '10:00',
-        });
+        }]);
     });
 
     test('handles 12:00pm noon correctly', () => {
-        expect(parseMeetingTime('M 12:00pm - 1:00pm')).toEqual({
+        expect(parseMeetingTime('M 12:00pm - 1:00pm')).toEqual([{
             days: ['Monday'],
             startTime: '12:00',
             endTime: '13:00',
-        });
+        }]);
     });
 
     test('handles 12:30am correctly', () => {
-        expect(parseMeetingTime('T 12:30am - 2:00am')).toEqual({
+        expect(parseMeetingTime('T 12:30am - 2:00am')).toEqual([{
             days: ['Tuesday'],
             startTime: '00:30',
             endTime: '02:00',
-        });
+        }]);
     });
 
     test('returns null for TBA', () => {

--- a/lib/parse-meeting-times.ts
+++ b/lib/parse-meeting-times.ts
@@ -2,7 +2,8 @@ const DAY_MAP: Record<string, string> = {
     M: 'Monday',
     T: 'Tuesday',
     W: 'Wednesday',
-    R: 'Thursday',
+    R: 'Thursday', // Backwards compatibility for MTWRF
+    TH: 'Thursday', // New format support
     F: 'Friday',
     S: 'Saturday',
     U: 'Sunday',
@@ -27,44 +28,78 @@ function convertTime12to24(time12h: string): string {
     return `${hours24}:${minutes}`;
 }
 
-export function parseMeetingTime(meetingTimeStr: string): { days: string[], startTime: string, endTime: string } | null {
-    if (!meetingTimeStr || meetingTimeStr.trim() === 'TBA') {
+export interface ParsedMeetingTime {
+    days: string[];
+    startTime: string;
+    endTime: string;
+}
+
+export function parseMeetingTime(meetingTimeStr: string): ParsedMeetingTime[] | null {
+    if (!meetingTimeStr || meetingTimeStr.trim().toUpperCase() === 'TBA') {
         return null;
     }
 
-    // Normalize: replace en-dash/em-dash with hyphen, collapse whitespace
-    const normalized = meetingTimeStr
-        .trim()
-        .replace(/[\u2013\u2014]/g, '-')
-        .replace(/\s+/g, ' ');
+    // Split by semicolons for multiple schedule segments (e.g. Lecture and Lab)
+    const schedules = meetingTimeStr.split(';');
+    const results: ParsedMeetingTime[] = [];
 
-    // Regex to match:
-    // 1: days (M, T, W, R, F, S, U with optional spaces)
-    // 2: start time (1:35 pm or 1:35pm)
-    // 3: end time (2:40 pm or 2:40pm)
-    const match = normalized.match(/^([MTWRFSU\s]+?)\s+(\d{1,2}:\d{2}\s*[aApP]\s*[mM])\s*-\s*(\d{1,2}:\d{2}\s*[aApP]\s*[mM])$/);
+    for (const schedule of schedules) {
+        // Normalize: replace en-dash/em-dash with hyphen, collapse whitespace
+        const normalized = schedule
+            .trim()
+            .replace(/[\u2013\u2014]/g, '-')
+            .replace(/\s+/g, ' ');
 
-    // Try relaxed regex if strict one doesn't match
-    let daysStr, startTime12, endTime12;
+        // Regex to match:
+        // 1: days (M, T, W, R, F, S, U, Th, comma-separated or space-separated or tight)
+        // 2: start time (1:35 pm or 1:35pm)
+        // 3: end time (2:40 pm or 2:40pm)
+        const match = normalized.match(/^([^\d]+?)\s+(\d{1,2}:\d{2}\s*[aApP]\s*[mM])\s*-\s*(\d{1,2}:\d{2}\s*[aApP]\s*[mM])$/);
 
-    if (match) {
-        daysStr = match[1].replace(/\s+/g, ''); // remove internal spaces in days
-        startTime12 = match[2];
-        endTime12 = match[3];
-    } else {
-        // maybe no space between days and time?
-        const tightMatch = normalized.match(/^([MTWRFSU]+)(\d{1,2}:\d{2}\s*[aApP]\s*[mM])\s*-\s*(\d{1,2}:\d{2}\s*[aApP]\s*[mM])$/);
-        if (!tightMatch) return null;
-        daysStr = tightMatch[1];
-        startTime12 = tightMatch[2];
-        endTime12 = tightMatch[3];
+        // Try tight match without space between days and time
+        const tightMatch = normalized.match(/^([^\d]+)(\d{1,2}:\d{2}\s*[aApP]\s*[mM])\s*-\s*(\d{1,2}:\d{2}\s*[aApP]\s*[mM])$/);
+
+        let daysStr = '';
+        let startTime12 = '';
+        let endTime12 = '';
+
+        if (match) {
+            daysStr = match[1];
+            startTime12 = match[2];
+            endTime12 = match[3];
+        } else if (tightMatch) {
+            daysStr = tightMatch[1];
+            startTime12 = tightMatch[2];
+            endTime12 = tightMatch[3];
+        } else {
+            // Unparseable segment, skip to next
+            continue;
+        }
+
+        // Parse days. They might be comma separated "M,W,Th", or tight "MTWRF"
+        let days: string[] = [];
+
+        if (daysStr.includes(',')) {
+            days = daysStr.split(',')
+                .map(d => d.trim().toUpperCase())
+                .map(d => DAY_MAP[d])
+                .filter(Boolean);
+        } else {
+            // Legacy tight parsing
+            // Replace Th with R temporarily for character iteration
+            const normalizedTightDays = daysStr.replace(/\s+/g, '').replace(/Th/g, 'R');
+            days = normalizedTightDays.split('')
+                .map(char => DAY_MAP[char.toUpperCase()])
+                .filter(Boolean);
+        }
+
+        if (days.length === 0) continue;
+
+        const startTime = convertTime12to24(startTime12);
+        const endTime = convertTime12to24(endTime12);
+
+        results.push({ days, startTime, endTime });
     }
 
-    const days = daysStr.split('').map(char => DAY_MAP[char.toUpperCase()]).filter(Boolean);
-    if (days.length === 0) return null;
-
-    const startTime = convertTime12to24(startTime12);
-    const endTime = convertTime12to24(endTime12);
-
-    return { days, startTime, endTime };
+    return results.length > 0 ? results : null;
 }

--- a/lib/parse-meeting-times.ts
+++ b/lib/parse-meeting-times.ts
@@ -1,0 +1,70 @@
+const DAY_MAP: Record<string, string> = {
+    M: 'Monday',
+    T: 'Tuesday',
+    W: 'Wednesday',
+    R: 'Thursday',
+    F: 'Friday',
+    S: 'Saturday',
+    U: 'Sunday',
+};
+
+function convertTime12to24(time12h: string): string {
+    // Remove spaces before am/pm
+    const cleaned = time12h.replace(/\s+/g, '').toLowerCase();
+    const match = cleaned.match(/^(\d{1,2}):(\d{2})(am|pm)$/);
+    if (!match) return time12h;
+
+    let [_, hoursStr, minutes, modifier] = match;
+    let hours = parseInt(hoursStr, 10);
+
+    if (hours === 12) {
+        hours = modifier === 'am' ? 0 : 12;
+    } else if (modifier === 'pm') {
+        hours += 12;
+    }
+
+    const hours24 = hours.toString().padStart(2, '0');
+    return `${hours24}:${minutes}`;
+}
+
+export function parseMeetingTime(meetingTimeStr: string): { days: string[], startTime: string, endTime: string } | null {
+    if (!meetingTimeStr || meetingTimeStr.trim() === 'TBA') {
+        return null;
+    }
+
+    // Normalize: replace en-dash/em-dash with hyphen, collapse whitespace
+    const normalized = meetingTimeStr
+        .trim()
+        .replace(/[\u2013\u2014]/g, '-')
+        .replace(/\s+/g, ' ');
+
+    // Regex to match:
+    // 1: days (M, T, W, R, F, S, U with optional spaces)
+    // 2: start time (1:35 pm or 1:35pm)
+    // 3: end time (2:40 pm or 2:40pm)
+    const match = normalized.match(/^([MTWRFSU\s]+?)\s+(\d{1,2}:\d{2}\s*[aApP]\s*[mM])\s*-\s*(\d{1,2}:\d{2}\s*[aApP]\s*[mM])$/);
+
+    // Try relaxed regex if strict one doesn't match
+    let daysStr, startTime12, endTime12;
+
+    if (match) {
+        daysStr = match[1].replace(/\s+/g, ''); // remove internal spaces in days
+        startTime12 = match[2];
+        endTime12 = match[3];
+    } else {
+        // maybe no space between days and time?
+        const tightMatch = normalized.match(/^([MTWRFSU]+)(\d{1,2}:\d{2}\s*[aApP]\s*[mM])\s*-\s*(\d{1,2}:\d{2}\s*[aApP]\s*[mM])$/);
+        if (!tightMatch) return null;
+        daysStr = tightMatch[1];
+        startTime12 = tightMatch[2];
+        endTime12 = tightMatch[3];
+    }
+
+    const days = daysStr.split('').map(char => DAY_MAP[char.toUpperCase()]).filter(Boolean);
+    if (days.length === 0) return null;
+
+    const startTime = convertTime12to24(startTime12);
+    const endTime = convertTime12to24(endTime12);
+
+    return { days, startTime, endTime };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hello-pangea/dnd": "^18.0.1",
         "@heroicons/react": "^2.2.0",
         "cheerio": "^1.2.0",
+        "date-fns": "^4.1.0",
         "firebase": "^12.10.0",
         "firebase-admin": "^13.7.0",
         "ics": "^3.8.1",
@@ -5406,6 +5407,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@heroicons/react": "^2.2.0",
     "cheerio": "^1.2.0",
+    "date-fns": "^4.1.0",
     "firebase": "^12.10.0",
     "firebase-admin": "^13.7.0",
     "ics": "^3.8.1",

--- a/scripts/scrape-courses.ts
+++ b/scripts/scrape-courses.ts
@@ -266,8 +266,79 @@ async function scrapeSearchNeu(limit: number = 0): Promise<Course[]> {
                                 const seatsMatch = rawSeats.match(/(\d+)\s*\/\s*(\d+)/);
                                 const seats = seatsMatch ? `${seatsMatch[1]} / ${seatsMatch[2]}` : rawSeats.trim();
 
-                                const rawTime = await tds.nth(3).innerText();
-                                const timeText = rawTime.trim().replace(/\s+/g, ' ');
+                                const timeData = await tds.nth(3).evaluate((td) => {
+                                    const meetingGroups = Array.from(td.querySelectorAll('div.flex.w-full.flex-col.gap-1'));
+
+                                    if (meetingGroups.length > 0) {
+                                        const parsedMeetings: string[] = [];
+
+                                        meetingGroups.forEach(group => {
+                                            const spans = group.querySelectorAll('span.flex.items-center.gap-1');
+                                            let activeDays: string[] = [];
+                                            let timeString = '';
+
+                                            if (spans.length >= 2) {
+                                                const daysSpan = spans[0];
+                                                const timeSpan = spans[1];
+
+                                                Array.from(daysSpan.children).forEach((child, index) => {
+                                                    if (child.classList.contains('text-neu9')) {
+                                                        if (index === 0) activeDays.push('M');
+                                                        else if (index === 1) activeDays.push('T');
+                                                        else if (index === 2) activeDays.push('W');
+                                                        else if (index === 3) activeDays.push('Th');
+                                                        else if (index === 4) activeDays.push('F');
+                                                        else if (index === 5) activeDays.push('S');
+                                                        else if (index === 6) activeDays.push('U');
+                                                    }
+                                                });
+
+                                                timeString = timeSpan.textContent ? timeSpan.textContent.trim().replace(/\s+/g, ' ') : '';
+                                            } else if (spans.length === 1) {
+                                                // It might just be "TBA"
+                                                timeString = spans[0].textContent ? spans[0].textContent.trim() : '';
+                                            }
+
+                                            // Handle edge cases where days are embedded differently
+                                            if (activeDays.length > 0) {
+                                                parsedMeetings.push(`${activeDays.join(',')}${timeString ? ' ' + timeString : ''}`);
+                                            } else {
+                                                if (timeString) parsedMeetings.push(timeString);
+                                            }
+                                        });
+
+                                        return parsedMeetings.length > 0 ? parsedMeetings.join('; ') : td.textContent?.trim() || '';
+                                    }
+
+                                    // Fallback to simple DOM parsing if layout is simpler
+                                    const daysSpan = td.querySelector('span.flex.items-center.gap-1');
+                                    let activeDays: string[] = [];
+
+                                    if (daysSpan) {
+                                        Array.from(daysSpan.children).forEach((child, index) => {
+                                            if (child.classList.contains('text-neu9')) {
+                                                if (index === 0) activeDays.push('M');
+                                                else if (index === 1) activeDays.push('T');
+                                                else if (index === 2) activeDays.push('W');
+                                                else if (index === 3) activeDays.push('Th');
+                                                else if (index === 4) activeDays.push('F');
+                                                else if (index === 5) activeDays.push('S');
+                                                else if (index === 6) activeDays.push('U');
+                                            }
+                                        });
+                                    }
+
+                                    let rawTimeText = td.textContent || '';
+                                    rawTimeText = rawTimeText.replace(/M\s*T\s*W\s*T\s*F/gi, '').trim();
+
+                                    if (activeDays.length > 0) {
+                                        return `${activeDays.join(',')}${rawTimeText ? ' ' + rawTimeText.replace(/\s+/g, ' ') : ''}`;
+                                    } else {
+                                        return td.textContent ? td.textContent.trim().replace(/\s+/g, ' ') : '';
+                                    }
+                                });
+
+                                const timeText = timeData;
 
                                 const rooms = (await tds.nth(4).innerText()).trim();
                                 const professor = (await tds.nth(5).innerText()).trim();


### PR DESCRIPTION
## Changes by Issue

### Issue #6 — Event Editing (PUT route + edit UI)
- Added `PUT /api/v1/events/[eventId]` route to update an existing event
- Added `updateEvent(id, data)` to `useEvents` hook
- Calendar page: clicking an existing event populates the form; "Update Event" / "Cancel Edit" buttons
- Fixed calendar page: 24h timeline, date picker, overlap detection
- **Tests:** `hooks/useEvents.test.ts`

### Bug Fix — Immediate UI refresh after adding semester/course
- Root cause: `AddSemesterModal` and `QuickAddModal` were calling `usePlanDetails()` internally, creating separate React state from the parent page
- Fix: hook calls removed from both modals; `addSemester` and `addCourseToSemester` passed as props from `app/plans/[planId]/page.tsx`

### Bug Fix — Dashboard showed "0 Semesters" for all plans
- `GET /api/v1/plans` now fetches `semesterCount` per plan from the semesters subcollection
- Dashboard reads `plan.semesterCount` instead of `plan.semesters?.length`

### Issue #7 — Plan-to-Calendar Integration
- New `lib/parse-meeting-times.ts`: parses meeting time strings like `"MWF 10:30am – 11:35am"` into `{ days, startTime, endTime }` (handles en-dash, no-space formats, 12h→24h)
- New `components/AddToCalendarButton.tsx`: adds a course section's recurring weekly schedule to the calendar
- New `components/AddScheduleToCalendarModal.tsx`: triggered from plan header — batch-add all plan courses to calendar
- **Tests:** `lib/parse-meeting-times.test.ts`, `components/AddToCalendarButton.test.tsx`, `components/AddScheduleToCalendarModal.test.tsx`

### Issue #8 — ICS / Calendar Export
- `app/calendar/page.tsx` exports all events (including course schedule events added via #7) to a `.ics` file
- Students can add their course schedules to the calendar via #7, then export the full `.ics` for Google Calendar

### Issue #5 — Specific Prereq/Coreq Warnings
- `CourseMiniCard` now shows which courses are missing: `"Prereq needed: CS1800, CS2500"` instead of generic `"Missing Prereq"`
- Added `aria-label` and `title` for accessibility
- **Tests:** `components/CourseMiniCard.test.tsx` — 6 scenarios

### Issue #9 — Plan Rename
- Added `PUT /api/v1/plans/[planId]` route: validates name, checks plan exists, updates with `updatedAt: serverTimestamp()`
- Added `renamePlan(planId, newName)` to `usePlans` hook (optimistic local update)
- Plans page: inline rename per row — click "Rename", edit in-place, Save/Cancel, Enter to confirm, Escape to cancel

---

## How to Test

### Prerequisites
Check out `joythish-sprint1`, run `npm install && npm run dev`, log in with a test account.

### Event Editing (#6)
1. Go to `/calendar`, create an event — appears on timeline immediately
2. Click the event — form populates, shows "Update Event"
3. Edit title, click "Update Event" — updates in place
4. "Cancel Edit" — form clears back to "Add Event"

### Immediate UI refresh (bug fix)
1. Open a plan detail page
2. "Add Semester" — new semester appears **without page refresh**
3. "Quick Add" a course — appears **without page refresh**

### Dashboard semester count (bug fix)
1. Go to `/dashboard` — each plan card shows correct semester count (not "0 Semesters")

### Plan-to-Calendar + ICS Export (#7 + #8)
1. Open a plan that has courses with a CRN selected
2. Click "Add to Calendar" in the plan header
3. Modal shows courses with meeting times — click "Add to Calendar" for one
4. Go to `/calendar` — verify weekly events were added for each day of the week
5. Click "Export .ics" — download the file and import into Google Calendar to verify course events appear

### Prereq/Coreq Warnings (#5)
1. Open a plan, add a course with prereqs (e.g. CS3500 needs CS1800, CS2500)
2. Card shows `"Prereq needed: CS1800, CS2500"` in orange
3. Add the missing courses in earlier semesters — warning disappears

### Plan Rename (#9)
1. Go to `/plans`, click "Rename" next to any plan
2. Inline input appears pre-filled with current name
3. Edit and press Enter or Save — name updates immediately
4. Refresh — renamed plan persists
5. Press Escape while renaming — cancels without saving

---

Closes #5, #6, #7, #8, #9