### PR TITLE
feat(plans): add graduation requirements tracking

### DIFF
--- a/app/api/v1/plans/[planId]/route.ts
+++ b/app/api/v1/plans/[planId]/route.ts
@@ -193,3 +193,113 @@ export async function PUT(
         return errorResponse('Failed to rename degree plan', 'INTERNAL_SERVER_ERROR', 500);
     }
 }
+
+/**
+ * @swagger
+ * /api/v1/plans/{planId}:
+ *   patch:
+ *     summary: Update a specific degree plan (partial update)
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: planId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               requirements:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   required:
+ *                     - id
+ *                     - name
+ *                     - count
+ *                   properties:
+ *                     id:
+ *                       type: string
+ *                     name:
+ *                       type: string
+ *                     count:
+ *                       type: number
+ *     responses:
+ *       200:
+ *         description: Plan updated successfully
+ *       400:
+ *         description: Invalid request body
+ *       404:
+ *         description: Plan not found
+ */
+export async function PATCH(
+    request: NextRequest,
+    context: { params: Promise<{ planId: string }> }
+) {
+    const { user, error } = await verifyAuth(request);
+
+    if (error || !user) {
+        return errorResponse(error || 'Unauthorized', 'UNAUTHORIZED', 401);
+    }
+
+    try {
+        const { planId } = await context.params;
+        const body = await request.json().catch(() => ({}));
+
+        if (Object.keys(body).length === 0) {
+            return errorResponse('Request body is empty', 'BAD_REQUEST', 400);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const updateData: any = {
+            updatedAt: FieldValue.serverTimestamp()
+        };
+
+        if (body.name !== undefined) {
+            if (typeof body.name !== 'string' || body.name.trim() === '') {
+                return errorResponse('Valid plan name is required', 'BAD_REQUEST', 400);
+            }
+            updateData.name = body.name.trim();
+        }
+
+        if (body.requirements !== undefined) {
+            if (!Array.isArray(body.requirements)) {
+                return errorResponse('Requirements must be an array', 'BAD_REQUEST', 400);
+            }
+            // Basic validation
+            for (const req of body.requirements) {
+                if (!req.id || !req.name || typeof req.count !== 'number') {
+                    return errorResponse('Invalid requirement format', 'BAD_REQUEST', 400);
+                }
+            }
+            updateData.requirements = body.requirements;
+        }
+
+        const planRef = adminDb
+            .collection('users')
+            .doc(user.uid)
+            .collection('plans')
+            .doc(planId);
+
+        const planDoc = await planRef.get();
+
+        if (!planDoc.exists) {
+            return errorResponse(`Plan ${planId} not found.`, 'NOT_FOUND', 404);
+        }
+
+        await planRef.update(updateData);
+
+        return successResponse({ id: planId, ...updateData });
+    } catch (err) {
+        console.error('Error updating plan:', err);
+        return errorResponse('Failed to update degree plan', 'INTERNAL_SERVER_ERROR', 500);
+    }
+}
+

--- a/app/plans/[planId]/page.tsx
+++ b/app/plans/[planId]/page.tsx
@@ -9,7 +9,8 @@ import Link from 'next/link';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import AddSemesterModal from '@/components/AddSemesterModal';
 import QuickAddModal from '@/components/QuickAddModal';
-import { TrashIcon, PlusIcon, MagnifyingGlassPlusIcon } from '@heroicons/react/24/outline';
+import GraduationRequirementsModal from '@/components/GraduationRequirementsModal';
+import { TrashIcon, PlusIcon, MagnifyingGlassPlusIcon, ClipboardDocumentListIcon } from '@heroicons/react/24/outline';
 import { fetchCourseCached } from '@/hooks/useSingleCourse';
 import { CourseAssignment } from '@/hooks/usePlanDetails';
 import { CalendarIcon } from '@heroicons/react/24/outline';
@@ -81,7 +82,8 @@ export default function PlanDetailsPage() {
         moveCourseBetweenSemesters,
         removeCourseFromSemester,
         addSemester,
-        addCourseToSemester
+        addCourseToSemester,
+        updateRequirements
     } = usePlanDetails(planId);
 
     const router = useRouter();
@@ -89,6 +91,7 @@ export default function PlanDetailsPage() {
     const [isAddSemesterOpen, setIsAddSemesterOpen] = useState(false);
     const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
     const [isCalendarModalOpen, setIsCalendarModalOpen] = useState(false);
+    const [isRequirementsModalOpen, setIsRequirementsModalOpen] = useState(false);
     const [isBrowser, setIsBrowser] = useState(false);
 
     useEffect(() => {
@@ -188,6 +191,13 @@ export default function PlanDetailsPage() {
                         </h2>
                     </div>
                     <div className="mt-4 flex flex-wrap gap-3 md:mt-0 md:ml-4">
+                        <button
+                            onClick={() => setIsRequirementsModalOpen(true)}
+                            className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+                        >
+                            <ClipboardDocumentListIcon className="-ml-1 mr-2 h-5 w-5 text-gray-400" />
+                            Graduation Requirements
+                        </button>
                         <button
                             onClick={() => setIsCalendarModalOpen(true)}
                             className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
@@ -331,6 +341,13 @@ export default function PlanDetailsPage() {
                     isOpen={isCalendarModalOpen}
                     onClose={() => setIsCalendarModalOpen(false)}
                     semesters={plan.semesters || []}
+                />
+
+                <GraduationRequirementsModal
+                    isOpen={isRequirementsModalOpen}
+                    onClose={() => setIsRequirementsModalOpen(false)}
+                    requirements={plan.requirements}
+                    updateRequirements={updateRequirements}
                 />
 
                 <AddSemesterModal

--- a/components/GraduationRequirementsModal.test.tsx
+++ b/components/GraduationRequirementsModal.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import GraduationRequirementsModal from './GraduationRequirementsModal';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+describe('GraduationRequirementsModal', () => {
+    const mockUpdateRequirements = vi.fn().mockResolvedValue(true);
+    const mockOnClose = vi.fn();
+
+    const mockRequirements = [
+        { id: 'req1', name: 'Electives', count: 4 },
+        { id: 'req2', name: 'GenEds', count: 2 }
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders nothing when not open', () => {
+        const { container } = render(
+            <GraduationRequirementsModal
+                isOpen={false}
+                onClose={mockOnClose}
+                requirements={mockRequirements}
+                updateRequirements={mockUpdateRequirements}
+            />
+        );
+        expect(container.innerHTML).toBe('');
+    });
+
+    it('renders existing requirements when open', () => {
+        render(
+            <GraduationRequirementsModal
+                isOpen={true}
+                onClose={mockOnClose}
+                requirements={mockRequirements}
+                updateRequirements={mockUpdateRequirements}
+            />
+        );
+
+        expect(screen.getByText('Graduation Requirements')).toBeInTheDocument();
+        expect(screen.getByText('Electives')).toBeInTheDocument();
+        expect(screen.getByText('4 required')).toBeInTheDocument();
+        expect(screen.getByText('GenEds')).toBeInTheDocument();
+        expect(screen.getByText('2 required')).toBeInTheDocument();
+    });
+
+    it('adds a new requirement', async () => {
+        render(
+            <GraduationRequirementsModal
+                isOpen={true}
+                onClose={mockOnClose}
+                requirements={mockRequirements}
+                updateRequirements={mockUpdateRequirements}
+            />
+        );
+
+        const nameInput = screen.getByPlaceholderText('e.g. Electives, GenEd');
+        const countInput = screen.getByPlaceholderText('Count');
+        const addButton = screen.getByRole('button', { name: /Add/i });
+
+        fireEvent.change(nameInput, { target: { value: 'Major Cores' } });
+        fireEvent.change(countInput, { target: { value: '10' } });
+        fireEvent.click(addButton);
+
+        expect(screen.getByText('Major Cores')).toBeInTheDocument();
+        expect(screen.getByText('10 required')).toBeInTheDocument();
+    });
+
+    it('removes a requirement', async () => {
+        render(
+            <GraduationRequirementsModal
+                isOpen={true}
+                onClose={mockOnClose}
+                requirements={mockRequirements}
+                updateRequirements={mockUpdateRequirements}
+            />
+        );
+
+        expect(screen.getByText('Electives')).toBeInTheDocument();
+
+        const deleteButtons = screen.getAllByTitle('Remove requirement');
+        fireEvent.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.queryByText('Electives')).not.toBeInTheDocument();
+        });
+    });
+
+    it('saves changes and calls updateRequirements', async () => {
+        render(
+            <GraduationRequirementsModal
+                isOpen={true}
+                onClose={mockOnClose}
+                requirements={mockRequirements}
+                updateRequirements={mockUpdateRequirements}
+            />
+        );
+
+        const nameInput = screen.getByPlaceholderText('e.g. Electives, GenEd');
+        const countInput = screen.getByPlaceholderText('Count');
+        const addButton = screen.getByRole('button', { name: /Add/i });
+
+        fireEvent.change(nameInput, { target: { value: 'New Req' } });
+        fireEvent.change(countInput, { target: { value: '5' } });
+        fireEvent.click(addButton);
+
+        const saveButton = screen.getByRole('button', { name: /Save Changes/i });
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(mockUpdateRequirements).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({ name: 'Electives', count: 4 }),
+                    expect.objectContaining({ name: 'GenEds', count: 2 }),
+                    expect.objectContaining({ name: 'New Req', count: 5 })
+                ])
+            );
+            expect(mockOnClose).toHaveBeenCalled();
+        });
+    });
+});

--- a/components/GraduationRequirementsModal.tsx
+++ b/components/GraduationRequirementsModal.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { XMarkIcon, TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { GraduationRequirement } from '@/hooks/usePlans';
+
+interface GraduationRequirementsModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    requirements: GraduationRequirement[] | undefined;
+    updateRequirements: (requirements: GraduationRequirement[]) => Promise<void>;
+}
+
+export default function GraduationRequirementsModal({
+    isOpen,
+    onClose,
+    requirements = [],
+    updateRequirements
+}: GraduationRequirementsModalProps) {
+    const [localReqs, setLocalReqs] = useState<GraduationRequirement[]>([]);
+    const [newName, setNewName] = useState('');
+    const [newCount, setNewCount] = useState<number | ''>('');
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (isOpen) {
+            setLocalReqs([...requirements]);
+            setNewName('');
+            setNewCount('');
+            setError(null);
+            setIsSaving(false);
+        }
+    }, [isOpen, requirements]);
+
+    // Close on escape key
+    useEffect(() => {
+        const handleEsc = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+        document.addEventListener('keydown', handleEsc);
+        return () => document.removeEventListener('keydown', handleEsc);
+    }, [onClose]);
+
+    if (!isOpen) return null;
+
+    const handleAdd = (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmedName = newName.trim();
+        if (!trimmedName || newCount === '' || newCount <= 0) return;
+
+        const newReq: GraduationRequirement = {
+            id: crypto.randomUUID(),
+            name: trimmedName,
+            count: Number(newCount)
+        };
+
+        setLocalReqs([...localReqs, newReq]);
+        setNewName('');
+        setNewCount('');
+    };
+
+    const handleRemove = (idToRemove: string) => {
+        setLocalReqs(localReqs.filter(r => r.id !== idToRemove));
+    };
+
+    const handleSave = async () => {
+        setIsSaving(true);
+        setError(null);
+        try {
+            await updateRequirements(localReqs);
+            onClose();
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Unknown error occurred.');
+            setIsSaving(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 sm:p-0">
+            <div className="absolute inset-0 bg-gray-900/50 backdrop-blur-sm" onClick={onClose} />
+            <div className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg p-6 animate-in zoom-in-95 duration-200 text-left">
+                <div className="flex justify-between items-center mb-4 border-b border-gray-100 pb-3">
+                    <h3 className="text-lg font-bold text-gray-900">Graduation Requirements</h3>
+                    <button
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-gray-600 p-1 rounded-md hover:bg-gray-100 transition-colors"
+                    >
+                        <XMarkIcon className="w-5 h-5" />
+                    </button>
+                </div>
+
+                {error && (
+                    <div className="mb-4 rounded-md bg-red-50 p-3">
+                        <p className="text-sm text-red-700">{error}</p>
+                    </div>
+                )}
+
+                <div className="mb-6">
+                    <h4 className="text-sm font-medium text-gray-700 mb-2">Current Requirements</h4>
+                    {localReqs.length === 0 ? (
+                        <p className="text-sm text-gray-500 italic px-2 py-4 border-2 border-dashed border-gray-200 rounded-md text-center">
+                            No requirements added yet.
+                        </p>
+                    ) : (
+                        <ul className="space-y-2 border border-gray-200 rounded-md p-3 max-h-48 overflow-y-auto bg-gray-50/50">
+                            {localReqs.map((req) => (
+                                <li key={req.id} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0 last:pb-0">
+                                    <div className="flex items-center">
+                                        <span className="text-sm font-bold text-gray-900">{req.name}</span>
+                                        <span className="ml-3 inline-flex items-center rounded-md bg-indigo-50 px-2 py-1 text-xs font-semibold text-indigo-700 ring-1 ring-inset ring-indigo-600/20">
+                                            {req.count} required
+                                        </span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleRemove(req.id)}
+                                        className="text-gray-400 hover:text-red-600 bg-white p-1 rounded border border-transparent hover:border-red-200 transition-all"
+                                        title="Remove requirement"
+                                    >
+                                        <TrashIcon className="h-4 w-4" aria-hidden="true" />
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+
+                <form onSubmit={handleAdd} className="mt-4 border-t border-gray-200 pt-5">
+                    <h4 className="text-sm font-medium text-gray-700 mb-2">Add New Requirement</h4>
+                    <div className="flex gap-2 items-start">
+                        <div className="flex-1">
+                            <label htmlFor="req-name" className="sr-only">Requirement Name</label>
+                            <input
+                                type="text"
+                                id="req-name"
+                                placeholder="e.g. Electives, GenEd"
+                                value={newName}
+                                onChange={(e) => setNewName(e.target.value)}
+                                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-900"
+                            />
+                        </div>
+                        <div className="w-24">
+                            <label htmlFor="req-count" className="sr-only">Count</label>
+                            <input
+                                type="number"
+                                id="req-count"
+                                min="1"
+                                placeholder="Count"
+                                value={newCount}
+                                onChange={(e) => setNewCount(e.target.value === '' ? '' : Number(e.target.value))}
+                                className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm text-gray-900"
+                            />
+                        </div>
+                        <button
+                            type="submit"
+                            disabled={!newName.trim() || newCount === '' || newCount <= 0}
+                            className="inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            <PlusIcon className="h-4 w-4 mr-1 -ml-1" />
+                            Add
+                        </button>
+                    </div>
+                </form>
+
+                <div className="mt-8 flex justify-end gap-3 pt-4 border-t border-gray-100">
+                    <button
+                        type="button"
+                        className="px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-colors"
+                        onClick={onClose}
+                        disabled={isSaving}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        className="inline-flex justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 transition-colors"
+                        onClick={handleSave}
+                        disabled={isSaving}
+                    >
+                        {isSaving ? 'Saving...' : 'Save Changes'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/docs/logs/log-38.md
+++ b/docs/logs/log-38.md
@@ -1,0 +1,16 @@
+# Log 38
+**Date:** 2026-03-06
+**Author:** Assistant (for khajjafar)
+**Issue:** #31 - Create a way for people to add their graduation requirements
+
+## Actions Taken:
+- Created GitHub Issue #31 for adding graduation requirements tracking to the Plans tab.
+- Added `GraduationRequirement` interface and updated `Plan` to include `requirements` array in `hooks/usePlans.ts`.
+- Implemented `updateRequirements` function in `hooks/usePlanDetails.ts` using optimistic updates and a PATCH request.
+- Added a `PATCH` method to `/api/v1/plans/[planId]/route.ts` to allow partial updates of `name` and `requirements`.
+- Built `GraduationRequirementsModal` in `components/GraduationRequirementsModal.tsx` allowing users to view, add, and remove class types and required counts.
+- Integrated `GraduationRequirementsModal` into `app/plans/[planId]/page.tsx` with a new "Graduation Requirements" button.
+- Wrote and passed UI component tests in `components/GraduationRequirementsModal.test.tsx` and hook tests in `hooks/usePlanDetails.test.ts`.
+
+## Next Steps:
+- Pull request creation and code review.

--- a/hooks/usePlanDetails.test.ts
+++ b/hooks/usePlanDetails.test.ts
@@ -242,4 +242,33 @@ describe('usePlanDetails Hook', () => {
         expect(result.current.plan?.semesters[1].id).toBe('sem2');
         expect(result.current.plan?.semesters[1].courses).toEqual(['CS2000']);
     });
+
+    it('should update requirements optimistically', async () => {
+        vi.spyOn(useAuthHook, 'useAuth').mockReturnValue({
+            user: { uid: 'u1', getIdToken: mockGetIdToken }, loading: false, error: null
+        } as any);
+
+        const initialMock = {
+            id: 'p1', name: 'Plan', semesters: [], requirements: []
+        };
+
+        mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ data: initialMock }) });
+        const { result } = renderHook(() => usePlanDetails('p1'));
+        await waitFor(() => expect(result.current.plan).not.toBeNull());
+
+        mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ data: { id: 'p1' } }) });
+
+        const newRequirements = [{ id: 'req1', name: 'Electives', count: 4 }];
+
+        await act(async () => {
+            await result.current.updateRequirements(newRequirements);
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith('/api/v1/plans/p1', expect.objectContaining({
+            method: 'PATCH',
+            body: JSON.stringify({ requirements: newRequirements })
+        }));
+
+        expect(result.current.plan?.requirements).toEqual(newRequirements);
+    });
 });

--- a/hooks/usePlanDetails.ts
+++ b/hooks/usePlanDetails.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { Plan } from './usePlans';
+import { Plan, GraduationRequirement } from './usePlans';
 
 export interface CourseAssignment {
     courseId: string;
@@ -258,6 +258,30 @@ export function usePlanDetails(planId: string | null) {
         }
     };
 
+    const updateRequirements = async (requirements: GraduationRequirement[]) => {
+        if (!user || !planId) throw new Error("Missing authentication or Plan ID.");
+
+        // Optimistic UI update
+        setPlan(prevPlan => prevPlan ? { ...prevPlan, requirements } : prevPlan);
+
+        const token = await user.getIdToken();
+        const response = await fetch(`/api/v1/plans/${planId}`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`
+            },
+            body: JSON.stringify({ requirements })
+        });
+
+        if (!response.ok) {
+            // Revert on failure
+            await fetchPlanDetails();
+            const data = await response.json();
+            throw new Error(data.error?.message || 'Failed to update requirements');
+        }
+    };
+
     return {
         plan,
         loading: loading || authLoading,
@@ -267,6 +291,7 @@ export function usePlanDetails(planId: string | null) {
         reorderSemesters,
         moveCourseBetweenSemesters,
         addCourseToSemester,
-        removeCourseFromSemester
+        removeCourseFromSemester,
+        updateRequirements
     };
 }

--- a/hooks/usePlans.ts
+++ b/hooks/usePlans.ts
@@ -1,12 +1,19 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 
+export interface GraduationRequirement {
+    id: string;
+    name: string;
+    count: number;
+}
+
 export interface Plan {
     id: string;
     name: string;
     createdAt?: { seconds: number; nanoseconds: number } | string;
     updatedAt?: { seconds: number; nanoseconds: number } | string;
     semesterCount?: number;
+    requirements?: GraduationRequirement[];
 }
 
 export function usePlans() {


### PR DESCRIPTION
Implement graduation requirements as requested in issue #31.

## Acceptance Criteria
- [x] Requirements tool sits within the Plans tab.
- [x] A button called "Graduation Requirements" exists.
- [x] Clicking the button opens a popup/modal.
- [x] Students can add different class types (e.g., "Electives", "GenEds", etc.).
- [x] Students can specify the number of each class type needed to graduate.
- [x] Requirements data is saved to the user's plan in Firestore.

Closes #31